### PR TITLE
fix: Fix ctrl meta key swap (for real this time (i think))

### DIFF
--- a/src/app_model/backends/qt/_qkeymap.py
+++ b/src/app_model/backends/qt/_qkeymap.py
@@ -256,7 +256,7 @@ def qmods2modelmods(modifiers: Qt.KeyboardModifier) -> KeyMod:
     lookup = SWAPPED_KEYMOD_FROM_QT if mac_ctrl_meta_swapped() else KEYMOD_FROM_QT
     for modifier in lookup:
         if modifiers & modifier:
-            mod |= modifier
+            mod |= lookup[modifier]
     return mod
 
 

--- a/src/app_model/backends/qt/_qkeymap.py
+++ b/src/app_model/backends/qt/_qkeymap.py
@@ -40,7 +40,7 @@ _SWAPPED_QMOD_LOOKUP = {
 }
 
 
-def qt_swapped_ctrl_meta() -> bool:
+def mac_ctrl_meta_swapped() -> bool:
     """Determine whether Qt is swapping Ctrl and Meta for keyboard interactions."""
     return not QCoreApplication.testAttribute(Qt.AA_MacDontSwapCtrlAndMeta)
 
@@ -51,7 +51,7 @@ if QT6:
     def simple_keybinding_to_qint(skb: SimpleKeyBinding) -> int:
         """Create Qt Key integer from a SimpleKeyBinding."""
         lookup = (
-            _SWAPPED_QMOD_LOOKUP if MAC and qt_swapped_ctrl_meta() else _QMOD_LOOKUP
+            _SWAPPED_QMOD_LOOKUP if MAC and mac_ctrl_meta_swapped() else _QMOD_LOOKUP
         )
         key = modelkey2qkey(skb.key) if skb.key else 0
         mods = (v for k, v in lookup.items() if getattr(skb, k))
@@ -64,7 +64,7 @@ else:
     def simple_keybinding_to_qint(skb: SimpleKeyBinding) -> int:
         """Create Qt Key integer from a SimpleKeyBinding."""
         lookup = (
-            _SWAPPED_QMOD_LOOKUP if MAC and qt_swapped_ctrl_meta() else _QMOD_LOOKUP
+            _SWAPPED_QMOD_LOOKUP if MAC and mac_ctrl_meta_swapped() else _QMOD_LOOKUP
         )
         out = modelkey2qkey(skb.key) if skb.key else 0
         mods = (v for k, v in lookup.items() if getattr(skb, k))
@@ -266,7 +266,7 @@ def qmods2modelmods(modifiers: Qt.KeyboardModifier) -> KeyMod:
     """Return KeyMod from Qt.KeyboardModifier."""
     mod = KeyMod.NONE
     lookup = (
-        MAC_KEYMOD_FROM_QT if MAC and not qt_swapped_ctrl_meta() else KEYMOD_FROM_QT
+        MAC_KEYMOD_FROM_QT if MAC and not mac_ctrl_meta_swapped() else KEYMOD_FROM_QT
     )
     for modifier in lookup:
         if modifiers & modifier:
@@ -276,7 +276,7 @@ def qmods2modelmods(modifiers: Qt.KeyboardModifier) -> KeyMod:
 
 def modelkey2qkey(key: KeyCode) -> Qt.Key:
     """Return Qt.Key from KeyCode."""
-    if MAC and qt_swapped_ctrl_meta():
+    if MAC and mac_ctrl_meta_swapped():
         if key == KeyCode.Meta:
             return Qt.Key.Key_Control
         if key == KeyCode.Ctrl:
@@ -286,7 +286,7 @@ def modelkey2qkey(key: KeyCode) -> Qt.Key:
 
 def qkey2modelkey(key: Qt.Key) -> KeyCode:
     """Return KeyCode from Qt.Key."""
-    if MAC and qt_swapped_ctrl_meta():
+    if MAC and mac_ctrl_meta_swapped():
         if key == Qt.Key.Key_Control:
             return KeyCode.Meta
         if key == Qt.Key.Key_Meta:

--- a/src/app_model/backends/qt/_qkeymap.py
+++ b/src/app_model/backends/qt/_qkeymap.py
@@ -207,9 +207,9 @@ KEY_TO_QT: Dict[Optional[KeyCode], Qt.Key] = {
 
 KEYMOD_FROM_QT = {
     Qt.KeyboardModifier.NoModifier: KeyMod.NONE,
-    Qt.KeyboardModifier.AltModifier: KeyMod.Alt,
+    QALT: KeyMod.Alt,
     QCTRL: KeyMod.CtrlCmd,
-    Qt.KeyboardModifier.ShiftModifier: KeyMod.Shift,
+    QSHIFT: KeyMod.Shift,
     QMETA: KeyMod.WinCtrl,
 }
 

--- a/src/app_model/backends/qt/_qkeymap.py
+++ b/src/app_model/backends/qt/_qkeymap.py
@@ -40,8 +40,8 @@ _SWAPPED_QMOD_LOOKUP = {
 }
 
 
-def mac_ctrl_meta_swapped() -> bool:
-    """Determine whether Qt is swapping Ctrl and Meta for keyboard interactions."""
+def _mac_ctrl_meta_swapped() -> bool:
+    """Return True if Qt is swapping Ctrl and Meta for keyboard interactions."""
     return not QCoreApplication.testAttribute(Qt.AA_MacDontSwapCtrlAndMeta)
 
 
@@ -51,7 +51,7 @@ if QT6:
     def simple_keybinding_to_qint(skb: SimpleKeyBinding) -> int:
         """Create Qt Key integer from a SimpleKeyBinding."""
         lookup = (
-            _SWAPPED_QMOD_LOOKUP if MAC and mac_ctrl_meta_swapped() else _QMOD_LOOKUP
+            _SWAPPED_QMOD_LOOKUP if MAC and _mac_ctrl_meta_swapped() else _QMOD_LOOKUP
         )
         key = modelkey2qkey(skb.key) if skb.key else 0
         mods = (v for k, v in lookup.items() if getattr(skb, k))
@@ -64,7 +64,7 @@ else:
     def simple_keybinding_to_qint(skb: SimpleKeyBinding) -> int:
         """Create Qt Key integer from a SimpleKeyBinding."""
         lookup = (
-            _SWAPPED_QMOD_LOOKUP if MAC and mac_ctrl_meta_swapped() else _QMOD_LOOKUP
+            _SWAPPED_QMOD_LOOKUP if MAC and _mac_ctrl_meta_swapped() else _QMOD_LOOKUP
         )
         out = modelkey2qkey(skb.key) if skb.key else 0
         mods = (v for k, v in lookup.items() if getattr(skb, k))
@@ -226,7 +226,6 @@ KEYMOD_TO_QT = {
 MAC_KEYMOD_TO_QT = {**KEYMOD_TO_QT, KeyMod.WinCtrl: QCTRL, KeyMod.CtrlCmd: QMETA}
 
 
-# unused/untested
 KEY_FROM_QT: Dict[Qt.Key, KeyCode] = {
     v.toCombined() if hasattr(v, "toCombined") else int(v): k
     for k, v in KEY_TO_QT.items()
@@ -266,7 +265,7 @@ def qmods2modelmods(modifiers: Qt.KeyboardModifier) -> KeyMod:
     """Return KeyMod from Qt.KeyboardModifier."""
     mod = KeyMod.NONE
     lookup = (
-        MAC_KEYMOD_FROM_QT if MAC and not mac_ctrl_meta_swapped() else KEYMOD_FROM_QT
+        MAC_KEYMOD_FROM_QT if MAC and not _mac_ctrl_meta_swapped() else KEYMOD_FROM_QT
     )
     for modifier in lookup:
         if modifiers & modifier:
@@ -276,17 +275,17 @@ def qmods2modelmods(modifiers: Qt.KeyboardModifier) -> KeyMod:
 
 def modelkey2qkey(key: KeyCode) -> Qt.Key:
     """Return Qt.Key from KeyCode."""
-    if MAC and mac_ctrl_meta_swapped():
+    if MAC and _mac_ctrl_meta_swapped():
         if key == KeyCode.Meta:
             return Qt.Key.Key_Control
         if key == KeyCode.Ctrl:
             return Qt.Key.Key_Meta
-    return KEY_TO_QT.get(key, 0)
+    return KEY_TO_QT.get(key, Qt.Key.Key_unknown)
 
 
 def qkey2modelkey(key: Qt.Key) -> KeyCode:
     """Return KeyCode from Qt.Key."""
-    if MAC and mac_ctrl_meta_swapped():
+    if MAC and _mac_ctrl_meta_swapped():
         if key == Qt.Key.Key_Control:
             return KeyCode.Meta
         if key == Qt.Key.Key_Meta:

--- a/src/app_model/backends/qt/_qkeymap.py
+++ b/src/app_model/backends/qt/_qkeymap.py
@@ -274,6 +274,11 @@ def qmods2modelmods(modifiers: Qt.KeyboardModifier) -> KeyMod:
 
 def qkey2modelkey(key: Qt.Key) -> KeyCode:
     """Return KeyCode from Qt.Key."""
+    if MAC and mac_ctrl_meta_swapped():
+        if key == Qt.Key.Key_Control:
+            return KeyCode.Meta
+        if key == Qt.Key.Key_Meta:
+            return KeyCode.Ctrl
     return KEY_FROM_QT.get(key, KeyCode.UNKNOWN)
 
 

--- a/tests/test_qt/test_qkeymap.py
+++ b/tests/test_qt/test_qkeymap.py
@@ -16,6 +16,18 @@ def test_qkey_lookup() -> None:
 
     assert qkey2modelkey(Qt.Key.Key_M) == KeyCode.KeyM
 
+    with patch.object(_qkeymap, "MAC", True):
+        with patch.object(_qkeymap, "mac_ctrl_meta_swapped", return_value=False):
+            assert qkey2modelkey(Qt.Key.Key_Control) == KeyCode.Ctrl
+            assert qkey2modelkey(Qt.Key.Key_Meta) == KeyCode.Meta
+        with patch.object(_qkeymap, "mac_ctrl_meta_swapped", return_value=True):
+            assert qkey2modelkey(Qt.Key.Key_Control) == KeyCode.Meta
+            assert qkey2modelkey(Qt.Key.Key_Meta) == KeyCode.Ctrl
+
+    with patch.object(_qkeymap, "MAC", False):
+        assert qkey2modelkey(Qt.Key.Key_Control) == KeyCode.Ctrl
+        assert qkey2modelkey(Qt.Key.Key_Meta) == KeyCode.Meta
+
 
 def test_qkeysequence2modelkeybinding() -> None:
     seq = QKeySequence(
@@ -31,22 +43,34 @@ def test_qkeysequence2modelkeybinding() -> None:
     assert qkeysequence2modelkeybinding(seq) == app_key
 
     with patch.object(_qkeymap, "MAC", True):
-        with patch.object(_qkeymap, "mac_ctrl_meta_swapped", return_value=True):
-            seq = QKeySequence(
-                Qt.Modifier.META | Qt.Key.Key_M,
-                Qt.KeyboardModifier.NoModifier | Qt.Key.Key_K,
-            )
-            app_key = KeyBinding(parts=[KeyMod.CtrlCmd | KeyCode.KeyM, KeyCode.KeyK])
-            assert qkeysequence2modelkeybinding(seq) == app_key
-
-            seq = QKeySequence(
-                Qt.Modifier.CTRL | Qt.Key.Key_M,
-                Qt.KeyboardModifier.NoModifier | Qt.Key.Key_K,
-            )
-            app_key = KeyBinding(parts=[KeyMod.WinCtrl | KeyCode.KeyM, KeyCode.KeyK])
-            assert qkeysequence2modelkeybinding(seq) == app_key
-
         with patch.object(_qkeymap, "mac_ctrl_meta_swapped", return_value=False):
+            # on Macs, unswapped, Meta -> Cmd
+            seq = QKeySequence(
+                Qt.Modifier.META | Qt.Key.Key_M,
+                Qt.KeyboardModifier.NoModifier | Qt.Key.Key_K,
+            )
+            app_key = KeyBinding(parts=[KeyMod.CtrlCmd | KeyCode.KeyM, KeyCode.KeyK])
+            assert qkeysequence2modelkeybinding(seq) == app_key
+
+            # on Macs, unswapped, Ctrl -> Ctrl
+            seq = QKeySequence(
+                Qt.Modifier.CTRL | Qt.Key.Key_M,
+                Qt.KeyboardModifier.NoModifier | Qt.Key.Key_K,
+            )
+            app_key = KeyBinding(parts=[KeyMod.WinCtrl | KeyCode.KeyM, KeyCode.KeyK])
+            assert qkeysequence2modelkeybinding(seq) == app_key
+
+            seq = QKeySequence(
+                Qt.Modifier.META | Qt.Key.Key_Meta,
+                Qt.Modifier.CTRL | Qt.Key.Key_Control,
+            )
+            app_key = KeyBinding(
+                parts=[KeyMod.CtrlCmd | KeyCode.Meta, KeyMod.WinCtrl | KeyCode.Ctrl]
+            )
+            assert qkeysequence2modelkeybinding(seq) == app_key
+
+        with patch.object(_qkeymap, "mac_ctrl_meta_swapped", return_value=True):
+            # on Mac swapped, Ctrl -> Meta/Cmd
             seq = QKeySequence(
                 Qt.Modifier.CTRL | Qt.Key.Key_M,
                 Qt.KeyboardModifier.NoModifier | Qt.Key.Key_K,
@@ -54,9 +78,45 @@ def test_qkeysequence2modelkeybinding() -> None:
             app_key = KeyBinding(parts=[KeyMod.CtrlCmd | KeyCode.KeyM, KeyCode.KeyK])
             assert qkeysequence2modelkeybinding(seq) == app_key
 
+            # on Mac swapped, Meta/Cmd -> Ctrl
             seq = QKeySequence(
                 Qt.Modifier.META | Qt.Key.Key_M,
                 Qt.KeyboardModifier.NoModifier | Qt.Key.Key_K,
             )
             app_key = KeyBinding(parts=[KeyMod.WinCtrl | KeyCode.KeyM, KeyCode.KeyK])
             assert qkeysequence2modelkeybinding(seq) == app_key
+
+            seq = QKeySequence(
+                Qt.Modifier.META | Qt.Key.Key_Meta,
+                Qt.Modifier.CTRL | Qt.Key.Key_Control,
+            )
+            app_key = KeyBinding(
+                parts=[KeyMod.WinCtrl | KeyCode.Ctrl, KeyMod.CtrlCmd | KeyCode.Meta]
+            )
+            assert qkeysequence2modelkeybinding(seq) == app_key
+
+    with patch.object(_qkeymap, "MAC", False):
+        # on Win/Unix, Ctrl -> Ctrl
+        seq = QKeySequence(
+            Qt.Modifier.CTRL | Qt.Key.Key_M,
+            Qt.KeyboardModifier.NoModifier | Qt.Key.Key_K,
+        )
+        app_key = KeyBinding(parts=[KeyMod.CtrlCmd | KeyCode.KeyM, KeyCode.KeyK])
+        assert qkeysequence2modelkeybinding(seq) == app_key
+
+        # on Win, Meta -> Win, on Unix, Meta -> Super
+        seq = QKeySequence(
+            Qt.Modifier.META | Qt.Key.Key_M,
+            Qt.KeyboardModifier.NoModifier | Qt.Key.Key_K,
+        )
+        app_key = KeyBinding(parts=[KeyMod.WinCtrl | KeyCode.KeyM, KeyCode.KeyK])
+        assert qkeysequence2modelkeybinding(seq) == app_key
+
+        seq = QKeySequence(
+            Qt.Modifier.META | Qt.Key.Key_Meta,
+            Qt.Modifier.CTRL | Qt.Key.Key_Control,
+        )
+        app_key = KeyBinding(
+            parts=[KeyMod.WinCtrl | KeyCode.Meta, KeyMod.CtrlCmd | KeyCode.Ctrl]
+        )
+        assert qkeysequence2modelkeybinding(seq) == app_key

--- a/tests/test_qt/test_qkeymap.py
+++ b/tests/test_qt/test_qkeymap.py
@@ -19,10 +19,10 @@ def test_modelkey_lookup() -> None:
     assert modelkey2qkey(KeyCode.KeyM) == Qt.Key.Key_M
 
     with patch.object(_qkeymap, "MAC", True):
-        with patch.object(_qkeymap, "mac_ctrl_meta_swapped", return_value=False):
+        with patch.object(_qkeymap, "_mac_ctrl_meta_swapped", return_value=False):
             assert modelkey2qkey(KeyCode.Ctrl) == Qt.Key.Key_Control
             assert modelkey2qkey(KeyCode.Meta) == Qt.Key.Key_Meta
-        with patch.object(_qkeymap, "mac_ctrl_meta_swapped", return_value=True):
+        with patch.object(_qkeymap, "_mac_ctrl_meta_swapped", return_value=True):
             assert modelkey2qkey(KeyCode.Meta) == Qt.Key.Key_Control
             assert modelkey2qkey(KeyCode.Ctrl) == Qt.Key.Key_Meta
 
@@ -39,10 +39,10 @@ def test_qkey_lookup() -> None:
     assert qkey2modelkey(Qt.Key.Key_M) == KeyCode.KeyM
 
     with patch.object(_qkeymap, "MAC", True):
-        with patch.object(_qkeymap, "mac_ctrl_meta_swapped", return_value=False):
+        with patch.object(_qkeymap, "_mac_ctrl_meta_swapped", return_value=False):
             assert qkey2modelkey(Qt.Key.Key_Control) == KeyCode.Ctrl
             assert qkey2modelkey(Qt.Key.Key_Meta) == KeyCode.Meta
-        with patch.object(_qkeymap, "mac_ctrl_meta_swapped", return_value=True):
+        with patch.object(_qkeymap, "_mac_ctrl_meta_swapped", return_value=True):
             assert qkey2modelkey(Qt.Key.Key_Control) == KeyCode.Meta
             assert qkey2modelkey(Qt.Key.Key_Meta) == KeyCode.Ctrl
 
@@ -56,13 +56,13 @@ def test_qmod_lookup() -> None:
     assert qmods2modelmods(Qt.KeyboardModifier.AltModifier) == KeyMod.Alt
 
     with patch.object(_qkeymap, "MAC", True):
-        with patch.object(_qkeymap, "mac_ctrl_meta_swapped", return_value=False):
+        with patch.object(_qkeymap, "_mac_ctrl_meta_swapped", return_value=False):
             assert (
                 qmods2modelmods(Qt.KeyboardModifier.ControlModifier) == KeyMod.WinCtrl
             )
             assert qmods2modelmods(Qt.KeyboardModifier.MetaModifier) == KeyMod.CtrlCmd
 
-        with patch.object(_qkeymap, "mac_ctrl_meta_swapped", return_value=True):
+        with patch.object(_qkeymap, "_mac_ctrl_meta_swapped", return_value=True):
             assert (
                 qmods2modelmods(Qt.KeyboardModifier.ControlModifier) == KeyMod.CtrlCmd
             )
@@ -87,7 +87,7 @@ def test_qkeysequence2modelkeybinding() -> None:
     assert qkeysequence2modelkeybinding(seq) == app_key
 
     with patch.object(_qkeymap, "MAC", True):
-        with patch.object(_qkeymap, "mac_ctrl_meta_swapped", return_value=False):
+        with patch.object(_qkeymap, "_mac_ctrl_meta_swapped", return_value=False):
             # on Macs, unswapped, Meta -> Cmd
             seq = QKeySequence(
                 Qt.Modifier.META | Qt.Key.Key_M,
@@ -113,7 +113,7 @@ def test_qkeysequence2modelkeybinding() -> None:
             )
             assert qkeysequence2modelkeybinding(seq) == app_key
 
-        with patch.object(_qkeymap, "mac_ctrl_meta_swapped", return_value=True):
+        with patch.object(_qkeymap, "_mac_ctrl_meta_swapped", return_value=True):
             # on Mac swapped, Ctrl -> Meta/Cmd
             seq = QKeySequence(
                 Qt.Modifier.CTRL | Qt.Key.Key_M,

--- a/tests/test_qt/test_qkeymap.py
+++ b/tests/test_qt/test_qkeymap.py
@@ -9,9 +9,26 @@ from app_model.backends.qt import (
     qkeysequence2modelkeybinding,
     qmods2modelmods,
 )
+from app_model.backends.qt._qkeymap import modelkey2qkey
 from app_model.types import KeyBinding, KeyCode, KeyCombo, KeyMod
 
 # stuff we don't know how to deal with yet
+
+
+def test_modelkey_lookup() -> None:
+    assert modelkey2qkey(KeyCode.KeyM) == Qt.Key.Key_M
+
+    with patch.object(_qkeymap, "MAC", True):
+        with patch.object(_qkeymap, "mac_ctrl_meta_swapped", return_value=False):
+            assert modelkey2qkey(KeyCode.Ctrl) == Qt.Key.Key_Control
+            assert modelkey2qkey(KeyCode.Meta) == Qt.Key.Key_Meta
+        with patch.object(_qkeymap, "mac_ctrl_meta_swapped", return_value=True):
+            assert modelkey2qkey(KeyCode.Meta) == Qt.Key.Key_Control
+            assert modelkey2qkey(KeyCode.Ctrl) == Qt.Key.Key_Meta
+
+    with patch.object(_qkeymap, "MAC", False):
+        assert modelkey2qkey(KeyCode.Ctrl) == Qt.Key.Key_Control
+        assert modelkey2qkey(KeyCode.Meta) == Qt.Key.Key_Meta
 
 
 def test_qkey_lookup() -> None:


### PR DESCRIPTION
yeah so i made an oopsie in https://github.com/pyapp-kit/app-model/pull/64 and only had the logic checking for modifier swaps... it now properly handles keycode swaps as well 😅 