### PR TITLE
refactor: Fix type annotation in action

### DIFF
--- a/src/app_model/types/_action.py
+++ b/src/app_model/types/_action.py
@@ -6,7 +6,7 @@ from pydantic import Field, validator
 
 from ._command_rule import CommandRule
 from ._keybinding_rule import KeyBindingRule
-from ._menu_rule import MenuRule
+from ._menu_rule import MenuRuleOrDict
 from ._utils import _validate_python_name
 
 # maintain runtime compatibility with older typing_extensions
@@ -41,7 +41,7 @@ class Action(CommandRule, Generic[P, R]):
         "`{obj.__module__}:{obj.__qualname__}` "
         "(e.g. `my_package.a_module:some_function`)",
     )
-    menus: Optional[List[MenuRule]] = Field(
+    menus: Optional[List[MenuRuleOrDict]] = Field(
         None,
         description="(Optional) Menus to which this action should be added.",
     )


### PR DESCRIPTION
Based on usage in napari:

https://github.com/napari/napari/blob/6416098946d594989072c2044551d7e0eca08328/napari/_app_model/actions/_layer_actions.py#L47

To avoid such messages 

![obraz](https://user-images.githubusercontent.com/3826210/229924495-9ef87869-e9c7-4234-93d1-013132d9982b.png)
