### PR TITLE
fix: don't use mixin for menus

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
           python -m pip install ${{ matrix.qt-backend }}
 
       - name: Test
-        uses: coactions/setup-xvfb@v1
+        uses: aganders3/headless-gui@v1
         with:
           run: python -m pytest -s --cov=app_model --cov-report=xml --cov-report=term-missing --color=yes
 

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -41,7 +41,7 @@ jobs:
           python -m pip install --pre ${{ matrix.qt-backend }}
 
       - name: Test
-        uses: GabrielBB/xvfb-action@v1
+        uses: aganders3/headless-gui@v1
         with:
           run: python -m pytest -s --color=yes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,11 +85,11 @@ line-length = 88
 src = ["src", "tests"]
 target-version = "py38"
 extend-select = [
-    "E",    # style errors
-    "F",    # flakes
-    "D",    # pydocstyle
+    "E", # style errors
+    "F", # flakes
+    "D", # pydocstyle
     "I", # isort
-    "U",    # pyupgrade
+    "U", # pyupgrade
     # "N",  # pep8-naming
     # "S",  # bandit
     "C",    # flake8-comprehensions
@@ -123,7 +123,10 @@ keep-runtime-typing = true
 # https://docs.pytest.org/en/6.2.x/customize.html
 [tool.pytest.ini_options]
 minversion = "6.0"
-filterwarnings = ["error", "ignore:QPixmapCache.find:DeprecationWarning:"]
+filterwarnings = [
+    "error",
+    "ignore:Enum value:DeprecationWarning:superqt",
+]
 
 # https://mypy.readthedocs.io/en/stable/config_file.html
 [tool.mypy]

--- a/src/app_model/backends/qt/__init__.py
+++ b/src/app_model/backends/qt/__init__.py
@@ -9,7 +9,7 @@ from ._qkeymap import (
     qmods2modelmods,
 )
 from ._qmainwindow import QModelMainWindow
-from ._qmenu import QModelMenu, QModelMenuBar, QModelSubmenu
+from ._qmenu import QModelMenu, QModelMenuBar, QModelSubmenu, QModelToolBar
 from ._util import to_qicon
 
 __all__ = [
@@ -25,6 +25,7 @@ __all__ = [
     "QModelMenu",
     "QModelMenuBar",
     "QModelSubmenu",
+    "QModelToolBar",
     "qmods2modelmods",
     "to_qicon",
 ]

--- a/src/app_model/backends/qt/_qmenu.py
+++ b/src/app_model/backends/qt/_qmenu.py
@@ -3,15 +3,15 @@ from __future__ import annotations
 from typing import (
     TYPE_CHECKING,
     Collection,
+    Iterable,
     List,
     Mapping,
     Optional,
-    Protocol,
     Set,
     Union,
+    cast,
 )
 
-from qtpy.QtCore import QObject
 from qtpy.QtWidgets import QMenu, QMenuBar, QToolBar
 
 from app_model import Application
@@ -29,99 +29,67 @@ if TYPE_CHECKING:
     from qtpy.QtWidgets import QAction, QWidget
 
 
-# fmt: off
-class _AcceptsMenus(Protocol):
-    _app: Application
-    def clear(self) -> None: ...
-    def addMenu(self, menu: QMenu) -> None: ...
-    def addAction(self, menu: QAction) -> None: ...
-    def addSeparator(self) -> None: ...
+def _rebuild(
+    menu: QMenu | QToolBar,
+    app: Application,
+    menu_id: str,
+    include_submenus: bool = True,
+    exclude: Optional[Collection[str]] = None,
+) -> None:
+    """Rebuild menu by looking up self._menu_id in menu_registry."""
+    menu.clear()
+    _exclude = exclude or set()
 
-# fmt: on
-
-
-class _MenuMixin(QObject):
-    _app: Application
-    _menu_id: str
-
-    def __init__(
-        self,
-        menu_id: str,
-        app: Union[str, Application],
-    ):
-        assert isinstance(menu_id, str), f"Expected str, got {type(menu_id)!r}"
-        self._menu_id = menu_id
-        self._app = Application.get_or_create(app) if isinstance(app, str) else app
-        self.setObjectName(menu_id)
-        self.rebuild()
-        self._app.menus.menus_changed.connect(self._on_registry_changed)
-        self.destroyed.connect(self._disconnect)
-
-    def _disconnect(self) -> None:
-        self._app.menus.menus_changed.disconnect(self._on_registry_changed)
-
-    def _on_registry_changed(self, changed_ids: Set[str]) -> None:
-        if self._menu_id in changed_ids:
-            self.rebuild()
-
-    def rebuild(
-        self: _MenuMixin,
-        include_submenus: bool = True,
-        exclude: Optional[Collection[str]] = None,
-    ) -> None:
-        """Rebuild menu by looking up self._menu_id in menu_registry."""
-        self.clear()
-        _exclude = exclude or set()
-
-        groups = list(self._app.menus.iter_menu_groups(self._menu_id))
-        n_groups = len(groups)
-        for n, group in enumerate(groups):
-            for item in group:
-                if isinstance(item, SubmenuItem) and include_submenus:
-                    submenu = QModelSubmenu(item, self._app, parent=self)
-                    self.addMenu(submenu)
-                elif item.command.id not in _exclude:  # type: ignore
-                    action = QMenuItemAction(
-                        item, app=self._app, parent=self  # type: ignore
-                    )
-                    self.addAction(action)
-            if n < n_groups - 1:
-                self.addSeparator()
-
-    def update_from_context(
-        self, ctx: Mapping[str, object], _recurse: bool = True
-    ) -> None:
-        """Update the enabled/visible state of each menu item with `ctx`.
-
-        See `app_model.expressions` for details on expressions.
-
-        Parameters
-        ----------
-        ctx : Mapping
-            A namespace that will be used to `eval()` the `'enablement'` and
-            `'when'` expressions provided for each action in the menu.
-            *ALL variables used in these expressions must either be present in
-            the `ctx` dict, or be builtins*.
-        _recurse : bool
-            recursion check, internal use only
-        """
-        for action in self.actions():
-            if isinstance(action, QMenuItemAction):
-                action.update_from_context(ctx)
-            elif not QT6 and isinstance(menu := action.menu(), QModelMenu):
-                menu.update_from_context(ctx)
-            elif isinstance(parent := action.parent(), QModelMenu):
-                # FIXME: this is a hack for Qt6 that I don't entirely understand.
-                # QAction has lost the `.menu()` method, and it's a bit hard to find
-                # how to get to the parent menu now. Checking parent() seems to work,
-                # but I'm not sure if it's the right thing to do, and it leads to a
-                # recursion error.  I stop it with the _recurse flag here, but I wonder
-                # whether that will cause other problems.
-                if _recurse:
-                    parent.update_from_context(ctx, _recurse=False)
+    groups = list(app.menus.iter_menu_groups(menu_id))
+    n_groups = len(groups)
+    for n, group in enumerate(groups):
+        for item in group:
+            if isinstance(item, SubmenuItem) and include_submenus:
+                submenu = QModelSubmenu(item, app, parent=menu)
+                cast("QMenu", menu).addMenu(submenu)
+            elif item.command.id not in _exclude:  # type: ignore
+                action = QMenuItemAction(item, app=app, parent=menu)  # type: ignore
+                menu.addAction(action)
+        if n < n_groups - 1:
+            menu.addSeparator()
 
 
-class QModelMenu(QMenu, _MenuMixin):
+def _update_from_context(
+    actions: Iterable[QAction], ctx: Mapping[str, object], _recurse: bool = True
+) -> None:
+    """Update the enabled/visible state of each menu item with `ctx`.
+
+    See `app_model.expressions` for details on expressions.
+
+    Parameters
+    ----------
+    actions : Iterable[QAction]
+        Actions to update.
+    ctx : Mapping
+        A namespace that will be used to `eval()` the `'enablement'` and
+        `'when'` expressions provided for each action in the menu.
+        *ALL variables used in these expressions must either be present in
+        the `ctx` dict, or be builtins*.
+    _recurse : bool
+        recursion check, internal use only
+    """
+    for action in actions:
+        if isinstance(action, QMenuItemAction):
+            action.update_from_context(ctx)
+        elif not QT6 and isinstance(menu := action.menu(), QModelMenu):
+            menu.update_from_context(ctx)
+        elif isinstance(parent := action.parent(), QModelMenu):
+            # FIXME: this is a hack for Qt6 that I don't entirely understand.
+            # QAction has lost the `.menu()` method, and it's a bit hard to find
+            # how to get to the parent menu now. Checking parent() seems to work,
+            # but I'm not sure if it's the right thing to do, and it leads to a
+            # recursion error.  I stop it with the _recurse flag here, but I wonder
+            # whether that will cause other problems.
+            if _recurse:
+                parent.update_from_context(ctx, _recurse=False)
+
+
+class QModelMenu(QMenu):
     """QMenu for a menu_id in an `app_model` MenusRegistry.
 
     Parameters
@@ -142,7 +110,17 @@ class QModelMenu(QMenu, _MenuMixin):
         parent: Optional[QWidget] = None,
     ):
         QMenu.__init__(self, parent)
-        _MenuMixin.__init__(self, menu_id, app)
+
+        # NOTE: code duplication with QModelToolBar, but Qt mixins and multiple
+        # inheritance are problematic for some versions of Qt, and for typing
+        assert isinstance(menu_id, str), f"Expected str, got {type(menu_id)!r}"
+        self._menu_id = menu_id
+        self._app = Application.get_or_create(app) if isinstance(app, str) else app
+        self.setObjectName(menu_id)
+        self.rebuild()
+        self._app.menus.menus_changed.connect(self._on_registry_changed)
+        self.destroyed.connect(self._disconnect)
+
         if title is not None:
             self.setTitle(title)
         self.aboutToShow.connect(self._on_about_to_show)
@@ -163,6 +141,44 @@ class QModelMenu(QMenu, _MenuMixin):
         for action in self.actions():
             if isinstance(action, QCommandRuleAction):
                 action._refresh()
+
+    def _disconnect(self) -> None:
+        self._app.menus.menus_changed.disconnect(self._on_registry_changed)
+
+    def _on_registry_changed(self, changed_ids: Set[str]) -> None:
+        if self._menu_id in changed_ids:
+            self.rebuild()
+
+    def update_from_context(
+        self, ctx: Mapping[str, object], _recurse: bool = True
+    ) -> None:
+        """Update the enabled/visible state of each menu item with `ctx`.
+
+        See `app_model.expressions` for details on expressions.
+
+        Parameters
+        ----------
+        ctx : Mapping
+            A namespace that will be used to `eval()` the `'enablement'` and
+            `'when'` expressions provided for each action in the menu.
+            *ALL variables used in these expressions must either be present in
+            the `ctx` dict, or be builtins*.
+        _recurse : bool
+            recursion check, internal use only
+        """
+        _update_from_context(self.actions(), ctx, _recurse=_recurse)
+
+    def rebuild(
+        self, include_submenus: bool = True, exclude: Optional[Collection[str]] = None
+    ) -> None:
+        """Rebuild menu by looking up self._menu_id in menu_registry."""
+        _rebuild(
+            menu=self,
+            app=self._app,
+            menu_id=self._menu_id,
+            include_submenus=include_submenus,
+            exclude=exclude,
+        )
 
 
 class QModelSubmenu(QModelMenu):
@@ -203,7 +219,7 @@ class QModelSubmenu(QModelMenu):
         # self.setVisible(expr.eval(ctx) if (expr := self._submenu.when) else True)
 
 
-class QModelToolBar(QToolBar, _MenuMixin):
+class QModelToolBar(QToolBar):
     """QToolBar that is built from a list of model menu ids."""
 
     def __init__(
@@ -217,18 +233,60 @@ class QModelToolBar(QToolBar, _MenuMixin):
     ) -> None:
         self._exclude = exclude
         QToolBar.__init__(self, parent)
-        _MenuMixin.__init__(self, menu_id, app)
+
+        # NOTE: code duplication with QModelMenu, but Qt mixins and multiple
+        # inheritance are problematic for some versions of Qt, and for typing
+        assert isinstance(menu_id, str), f"Expected str, got {type(menu_id)!r}"
+        self._menu_id = menu_id
+        self._app = Application.get_or_create(app) if isinstance(app, str) else app
+        self.setObjectName(menu_id)
+        self.rebuild()
+        self._app.menus.menus_changed.connect(self._on_registry_changed)
+        self.destroyed.connect(self._disconnect)
+
         if title is not None:
             self.setWindowTitle(title)
+
+    def addMenu(self, menu: QMenu) -> None:
+        """No-op for toolbar."""
+
+    def _disconnect(self) -> None:
+        self._app.menus.menus_changed.disconnect(self._on_registry_changed)
+
+    def _on_registry_changed(self, changed_ids: Set[str]) -> None:
+        if self._menu_id in changed_ids:
+            self.rebuild()
 
     def rebuild(
         self, include_submenus: bool = True, exclude: Optional[Collection[str]] = None
     ) -> None:
         """Rebuild toolbar by looking up self._menu_id in menu_registry."""
-        super().rebuild(include_submenus=include_submenus, exclude=self._exclude)
+        _rebuild(
+            menu=self,
+            app=self._app,
+            menu_id=self._menu_id,
+            include_submenus=include_submenus,
+            exclude=self._exclude,  # add comment as to why not use exclude?
+        )
 
-    def addMenu(self, menu: QMenu) -> None:
-        """No-op for toolbar."""
+    def update_from_context(
+        self, ctx: Mapping[str, object], _recurse: bool = True
+    ) -> None:
+        """Update the enabled/visible state of each menu item with `ctx`.
+
+        See `app_model.expressions` for details on expressions.
+
+        Parameters
+        ----------
+        ctx : Mapping
+            A namespace that will be used to `eval()` the `'enablement'` and
+            `'when'` expressions provided for each action in the menu.
+            *ALL variables used in these expressions must either be present in
+            the `ctx` dict, or be builtins*.
+        _recurse : bool
+            recursion check, internal use only
+        """
+        _update_from_context(self.actions(), ctx, _recurse=_recurse)
 
 
 class QModelMenuBar(QMenuBar):

--- a/tests/test_qt/test_qmenu.py
+++ b/tests/test_qt/test_qmenu.py
@@ -111,7 +111,7 @@ def test_shortcuts(qtbot: "QtBot", full_app: "FullApp") -> None:
 
     copy_action = menu.findAction(app.Commands.COPY)
 
-    with qtbot.waitSignal(copy_action.triggered, timeout=1000):
+    with qtbot.waitSignal(copy_action.triggered, timeout=2000):
         qtbot.keyClicks(win, "C", Qt.KeyboardModifier.ControlModifier)
 
     paste_action = menu.findAction(app.Commands.PASTE)


### PR DESCRIPTION
fixes #93 

while it helped reduce a little bit of code duplication, i was never particularly happy with the _MenuMixin anyway.  So this just removes it