### PR TITLE
fix: Amend preferences `StandardKeyBinding`

### DIFF
--- a/src/app_model/types/_keys/_standard_bindings.py
+++ b/src/app_model/types/_keys/_standard_bindings.py
@@ -123,7 +123,7 @@ _STANDARD_KEYS = [
     SK(StandardKeyBinding.NextChild, KeyMod.CtrlCmd | KeyCode.Tab, _, KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.BracketRight),
     SK(StandardKeyBinding.Open, KeyMod.CtrlCmd | KeyCode.KeyO),
     SK(StandardKeyBinding.Paste, KeyMod.CtrlCmd | KeyCode.KeyV),
-    SK(StandardKeyBinding.Preferences, _, _, KeyMod.CtrlCmd, KeyCode.Comma),
+    SK(StandardKeyBinding.Preferences, KeyMod.CtrlCmd | KeyCode.Comma),
     SK(StandardKeyBinding.PreviousChild, KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Tab, _, KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.BracketLeft),
     SK(StandardKeyBinding.Print, KeyMod.CtrlCmd | KeyCode.KeyP),
     SK(StandardKeyBinding.Quit, KeyMod.CtrlCmd | KeyCode.KeyQ),


### PR DESCRIPTION
[Qt](https://doc.qt.io/qt-6/qkeysequence.html#standard-shortcuts) suggests this shortcut for MacOS, with no bindings for Win or Linux. [VS code](https://code.visualstudio.com/docs/getstarted/keybindings#_keyboard-shortcuts-reference) uses this shortcut for all platforms.

I have amended primary key binding for 'preferences' to be `Ctrl + ,`. 
Another option is to follow Qt and only set keybinding to be this for Mac, leaving rest as None. Happy to change.