### PR TITLE
feat: Deprecate parsing unknown keys.

### DIFF
--- a/src/app_model/types/_keys/_keybindings.py
+++ b/src/app_model/types/_keys/_keybindings.py
@@ -1,4 +1,5 @@
 import re
+import warnings
 from typing import TYPE_CHECKING, Any, Callable, Dict, Generator, List, Optional, Tuple
 
 from pydantic import BaseModel, Field
@@ -77,6 +78,14 @@ class SimpleKeyBinding(BaseModel):
         """Parse a string into a SimpleKeyBinding."""
         mods, remainder = _parse_modifiers(key_str.strip())
         key = KeyCode.from_string(remainder)
+        if key == KeyCode.UNKNOWN:
+            warnings.warn(
+                f"Unknown key: {remainder!r}, this will become an error in the"
+                f" future. Please construct a {cls} directly if you wish to"
+                " have an Unknown Key.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         return cls(**mods, key=key)
 
     @classmethod

--- a/tests/test_keybindings.py
+++ b/tests/test_keybindings.py
@@ -46,13 +46,17 @@ def test_simple_keybinding_single_mod(mod: str, key: str) -> None:
     assert int(as_full_kb) == int(kb)
 
 
-def test_simple_keybinding_multi_mod():
+@pytest.mark.skipif(sys.platform != "darwin", reason="mac only")
+def test_simple_keybinding_multi_mod_mac():
     # here we're also testing that cmd and win get cast to 'KeyMod.CtrlCmd'
 
     kb = SimpleKeyBinding.from_str("cmd+shift+A")
     assert not kb.is_modifier_key()
     assert int(kb) & KeyMod.CtrlCmd | KeyMod.Shift
 
+
+@pytest.mark.skipif(sys.platform == "darwin", reason="win not defined on mac")
+def test_simple_keybinding_multi_mod_win():
     kb = SimpleKeyBinding.from_str("win+shift+A")
     assert not kb.is_modifier_key()
     assert int(kb) & KeyMod.CtrlCmd | KeyMod.Shift
@@ -98,6 +102,11 @@ def test_in_dict():
 
     with pytest.raises(KeyError):
         kbs[new_a]
+
+
+def test_warn_from_string_unknown():
+    with pytest.warns(DeprecationWarning):
+        KeyBinding.from_str("Shift+Return")
 
 
 def test_in_model():


### PR DESCRIPTION
This makes it invalid to parse win/cmd on non relevant platform, but I guess we could add placeholder values for those if we wish.

This should avoid parsing typoes