### PR TITLE
fix: propagate _recurse value in `QModelSubmenu.update_from_context` method

### DIFF
--- a/src/app_model/backends/qt/_qmenu.py
+++ b/src/app_model/backends/qt/_qmenu.py
@@ -155,7 +155,7 @@ class QModelSubmenu(QModelMenu):
         self, ctx: Mapping[str, object], _recurse: bool = True
     ) -> None:
         """Update the enabled state of this menu item from `ctx`."""
-        super().update_from_context(ctx)
+        super().update_from_context(ctx, _recurse=_recurse)
         self.setEnabled(expr.eval(ctx) if (expr := self._submenu.enablement) else True)
         # TODO: ... visibility needs to be controlled at the level of placement
         # in the submenu.  consider only using the `when` expression


### PR DESCRIPTION
It looks like _recurse value in `QModelSubmenu.update_from_context` is not propagated correctly. 

Without this, on the napari main branch, opening the file menu ends with (log truncated because of GHA limit):

```
/home/czaki/.pyenv/versions/napari/bin/python -m napari 
RecursionError: maximum recursion depth exceeded while calling a Python object

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/czaki/.pyenv/versions/napari/lib/python3.9/site-packages/app_model/backends/qt/_qmenu.py", line 99, in update_from_context
    _update_from_context(self.actions(), ctx, _recurse=_recurse)
  File "/home/czaki/.pyenv/versions/napari/lib/python3.9/site-packages/app_model/backends/qt/_qmenu.py", line 353, in _update_from_context
    parent.update_from_context(ctx, _recurse=False)
  File "/home/czaki/.pyenv/versions/napari/lib/python3.9/site-packages/app_model/backends/qt/_qmenu.py", line 158, in update_from_context
    super().update_from_context(ctx)
  File "/home/czaki/.pyenv/versions/napari/lib/python3.9/site-packages/app_model/backends/qt/_qmenu.py", line 99, in update_from_context
    _update_from_context(self.actions(), ctx, _recurse=_recurse)
  File "/home/czaki/.pyenv/versions/napari/lib/python3.9/site-packages/app_model/backends/qt/_qmenu.py", line 353, in _update_from_context
    parent.update_from_context(ctx, _recurse=False)
  File "/home/czaki/.pyenv/versions/napari/lib/python3.9/site-packages/app_model/backends/qt/_qmenu.py", line 158, in update_from_context
    super().update_from_context(ctx)
  File "/home/czaki/.pyenv/versions/napari/lib/python3.9/site-packages/app_model/backends/qt/_qmenu.py", line 99, in update_from_context
    _update_from_context(self.actions(), ctx, _recurse=_recurse)
  File "/home/czaki/.pyenv/versions/napari/lib/python3.9/site-packages/app_model/backends/qt/_qmenu.py", line 353, in _update_from_context
    parent.update_from_context(ctx, _recurse=False)
  File "/home/czaki/.pyenv/versions/napari/lib/python3.9/site-packages/app_model/backends/qt/_qmenu.py", line 158, in update_from_context
    super().update_from_context(ctx)
  File "/home/czaki/.pyenv/versions/napari/lib/python3.9/site-packages/app_model/backends/qt/_qmenu.py", line 99, in update_from_context
    _update_from_context(self.actions(), ctx, _recurse=_recurse)
  File "/home/czaki/.pyenv/versions/napari/lib/python3.9/site-packages/app_model/backends/qt/_qmenu.py", line 353, in _update_from_context
    parent.update_from_context(ctx, _recurse=False)
  File "/home/czaki/.pyenv/versions/napari/lib/python3.9/site-packages/app_model/backends/qt/_qmenu.py", line 158, in update_from_context
    super().update_from_context(ctx)
  File "/home/czaki/.pyenv/versions/napari/lib/python3.9/site-packages/app_model/backends/qt/_qmenu.py", line 99, in update_from_context
    _update_from_context(self.actions(), ctx, _recurse=_recurse)
  File "/home/czaki/.pyenv/versions/napari/lib/python3.9/site-packages/app_model/backends

...

  File "/home/czaki/.pyenv/versions/napari/lib/python3.9/site-packages/app_model/backends/qt/_qmenu.py", line 99, in update_from_context
    _update_from_context(self.actions(), ctx, _recurse=_recurse)
  File "/home/czaki/.pyenv/versions/napari/lib/python3.9/site-packages/app_model/backends/qt/_qmenu.py", line 353, in _update_from_context
    parent.update_from_context(ctx, _recurse=False)
  File "/home/czaki/.pyenv/versions/napari/lib/python3.9/site-packages/app_model/backends/qt/_qmenu.py", line 158, in update_from_context
    super().update_from_context(ctx)
  File "/home/czaki/.pyenv/versions/napari/lib/python3.9/site-packages/app_model/backends/qt/_qmenu.py", line 99, in update_from_context
    _update_from_context(self.actions(), ctx, _recurse=_recurse)
  File "/home/czaki/.pyenv/versions/napari/lib/python3.9/site-packages/app_model/backends/qt/_qmenu.py", line 353, in _update_from_context
    parent.update_from_context(ctx, _recurse=False)
  File "/home/czaki/.pyenv/versions/napari/lib/python3.9/site-packages/app_model/backends/qt/_qmenu.py", line 158, in update_from_context
    super().update_from_context(ctx)
  File "/home/czaki/.pyenv/versions/napari/lib/python3.9/site-packages/app_model/backends/qt/_qmenu.py", line 99, in update_from_context
    _update_from_context(self.actions(), ctx, _recurse=_recurse)
SystemError
```
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Refactor: Updated the `update_from_context` method in `src/app_model/backends/qt/_qmenu.py`. This change enhances the functionality of menu items by allowing their enabled state to be updated based on specific conditions. This provides a more dynamic and responsive user interface.
- Chore: Added a TODO comment to highlight future work needed for controlling visibility at the submenu level, paving the way for further UI improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->