### PR TITLE
feat: accept single string id as menu key in Actions.menus

### DIFF
--- a/src/app_model/types/_menu_rule.py
+++ b/src/app_model/types/_menu_rule.py
@@ -8,7 +8,7 @@ from typing import (
     Union,
 )
 
-from pydantic_compat import Field, field_validator
+from pydantic_compat import Field, field_validator, model_validator
 
 from app_model import expressions
 
@@ -64,6 +64,11 @@ class MenuRule(_MenuItemBase):
     """
 
     id: str = Field(..., description="Menu in which to place this item.")
+
+    @model_validator(mode="before")
+    def _validate_model(cls, v: Any) -> Any:
+        """If a single string is provided, convert to a dict with `id` key."""
+        return {"id": v} if isinstance(v, str) else v
 
 
 class MenuItem(_MenuItemBase):

--- a/src/app_model/types/_menu_rule.py
+++ b/src/app_model/types/_menu_rule.py
@@ -65,6 +65,14 @@ class MenuRule(_MenuItemBase):
 
     id: str = Field(..., description="Menu in which to place this item.")
 
+    # for v1
+    @classmethod
+    def _validate(cls: Type["MenuRule"], v: Any) -> Any:
+        if isinstance(v, str):
+            v = {"id": v}
+        return super()._validate(v)
+
+    # for v2
     @model_validator(mode="before")
     def _validate_model(cls, v: Any) -> Any:
         """If a single string is provided, convert to a dict with `id` key."""

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -12,7 +12,7 @@ MENUID = "some.menu.id"
 KWARGS = [
     {},
     {"enablement": "x == 1"},
-    {"menus": [{"id": MENUID}]},
+    {"menus": [MENUID]},  # test that we can pass menus as a single string too
     {"enablement": "3 >= 1", "menus": [{"id": MENUID}]},
     {"keybindings": [{"primary": PRIMARY_KEY}]},
     {
@@ -71,8 +71,9 @@ def test_register_action_decorator(kwargs, simple_app: Application, mode):
     menus = kwargs.get("menus", [])
     if menus := kwargs.get("menus"):
         for entry in menus:
-            assert entry["id"] in app.menus
-            app.menus_changed.assert_any_call({entry["id"]})
+            id_ = entry if isinstance(entry, str) else entry["id"]
+            assert id_ in app.menus
+            app.menus_changed.assert_any_call({id_})
     else:
         menus = list(app.menus)
         if kwargs.get("palette") is not False:


### PR DESCRIPTION
In many cases, an Action may be declared with a menu as :

```python
    types.Action(
        id="copy",
        menus=[{"id": MenuId.EDIT}],
    ),
```

this PR allows that to be simply
```python
    types.Action(
        id="copy",
        menus=[MenuId.EDIT],
    ),
```