### PR TITLE
feat: add `CommandRule.icon_visible_in_menu`

### DIFF
--- a/src/app_model/backends/qt/_qaction.py
+++ b/src/app_model/backends/qt/_qaction.py
@@ -92,6 +92,7 @@ class QCommandRuleAction(QCommandAction):
             self.setText(command_rule.title)
         if command_rule.icon:
             self.setIcon(to_qicon(command_rule.icon))
+        self.setIconVisibleInMenu(command_rule.icon_visible_in_menu)
         if command_rule.tooltip:
             self.setToolTip(command_rule.tooltip)
         if command_rule.status_tip:

--- a/src/app_model/types/_command_rule.py
+++ b/src/app_model/types/_command_rule.py
@@ -48,7 +48,7 @@ class CommandRule(_BaseModel):
     status_tip: Optional[str] = Field(
         None,
         description="(Optional) Help message to show in the status bar when a "
-        "button representing this command is hovered (For backends that support it).",
+        "button representing this command is hovered (for backends that support it).",
     )
     icon: Optional[Icon] = Field(
         None,
@@ -57,6 +57,11 @@ class CommandRule(_BaseModel):
         "such as `fa6-solid:arrow-down`, or "
         "[superqt.fonticon](https://pyapp-kit.github.io/superqt/utilities/fonticon/)"
         " keys, such as `fa6s.arrow_down`",
+    )
+    icon_visible_in_menu: bool = Field(
+        True,
+        description="Whether to show the icon in menus (for backends that support it). "
+        "If `False`, only the title will be shown. By default, `True`.",
     )
     enablement: Optional[expressions.Expr] = Field(
         None,

--- a/tests/test_qt/test_qactions.py
+++ b/tests/test_qt/test_qactions.py
@@ -2,7 +2,7 @@ from typing import TYPE_CHECKING
 from unittest.mock import Mock
 
 from app_model.backends.qt import QCommandRuleAction, QMenuItemAction
-from app_model.types import Action, MenuItem, ToggleRule
+from app_model.types import Action, CommandRule, MenuItem, ToggleRule
 
 if TYPE_CHECKING:
     from app_model import Application
@@ -58,3 +58,9 @@ def test_toggle_qaction(qapp, simple_app: "Application") -> None:
     a1._refresh()
     mock.assert_called_once()
     assert a1.isChecked()
+
+
+def test_icon_visible_in_menu(qapp, simple_app: "Application") -> None:
+    rule = CommandRule(id="test", title="Test", icon_visible_in_menu=False)
+    q_action = QCommandRuleAction(command_rule=rule, app=simple_app)
+    assert not q_action.isIconVisibleInMenu()


### PR DESCRIPTION
controls whether individual Action icons should be visible in menus.  Still controllable directly in the qt backend with `Qt.ApplicationAttribute.AA_DontShowIconsInMenus`