### PR TITLE
feat: add top level Application.context

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,7 @@ ignore = [
     "D203", # 1 blank line required before class docstring
     "D212", # Multi-line docstring summary should start at the first line
     "D213", # Multi-line docstring summary should start at the second line
+    "D401", # First line should be in imperative mood
     "D413", # Missing blank line after last section
     "D416", # Section name should end with a colon
 ]

--- a/src/app_model/backends/qt/_qaction.py
+++ b/src/app_model/backends/qt/_qaction.py
@@ -170,13 +170,8 @@ class QMenuItemAction(QCommandRuleAction):
             self._app.destroyed.connect(lambda: QMenuItemAction._cache.pop(key, None))
             self._initialized = True
 
-        # by updating from an empty context, anything that declares a "constant"
-        # enablement expression (like `'False'`) will be evaluated, allowing any
-        # menus that are always on/off, to be shown/hidden as needed.
-        # Everything else will fail without a proper context.
-        # TODO: as we improve where the context comes from, this could be removed.
         with contextlib.suppress(NameError):
-            self.update_from_context({})
+            self.update_from_context(self._app.context)
 
     def update_from_context(self, ctx: Mapping[str, object]) -> None:
         """Update the enabled/visible state of this menu item from `ctx`."""

--- a/src/app_model/expressions/__init__.py
+++ b/src/app_model/expressions/__init__.py
@@ -1,5 +1,5 @@
 """Abstraction on expressions, and contexts in which to evaluate them."""
-from ._context import Context, create_context, get_context
+from ._context import Context, app_model_context, create_context, get_context
 from ._context_keys import ContextKey, ContextKeyInfo, ContextNamespace
 from ._expressions import (
     BinOp,
@@ -15,13 +15,11 @@ from ._expressions import (
 )
 
 __all__ = [
+    "app_model_context",
     "BinOp",
     "BoolOp",
     "Compare",
     "Constant",
-    "IfExp",
-    "Name",
-    "UnaryOp",
     "Context",
     "ContextKey",
     "ContextKeyInfo",
@@ -29,6 +27,9 @@ __all__ = [
     "create_context",
     "Expr",
     "get_context",
+    "IfExp",
+    "Name",
     "parse_expression",
     "safe_eval",
+    "UnaryOp",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,17 @@
+from __future__ import annotations
+
 import sys
 from pathlib import Path
-from typing import List
+from typing import TYPE_CHECKING
 from unittest.mock import Mock
 
 import pytest
 
 from app_model import Action, Application
 from app_model.types import KeyCode, KeyMod, SubmenuItem
+
+if TYPE_CHECKING:
+    from typing import Iterator, NoReturn
 
 try:
     from fonticon_fa6 import FA6S
@@ -40,7 +45,7 @@ class Commands:
     RAISES = "raises.error"
 
 
-def _raise_an_error():
+def _raise_an_error() -> NoReturn:
     raise ValueError("This is an error")
 
 
@@ -101,7 +106,7 @@ def build_app(name: str = "complete_test_app") -> FullApp:
         ]
     )
 
-    actions: List[Action] = [
+    actions: list[Action] = [
         Action(
             id=Commands.OPEN,
             title="Open...",
@@ -211,7 +216,7 @@ def build_app(name: str = "complete_test_app") -> FullApp:
 
 
 @pytest.fixture
-def full_app(monkeypatch) -> Application:
+def full_app(monkeypatch: pytest.MonkeyPatch) -> Iterator[Application]:
     """Premade application."""
     try:
         app = build_app("complete_test_app")
@@ -228,7 +233,7 @@ def full_app(monkeypatch) -> Application:
 
 
 @pytest.fixture
-def simple_app():
+def simple_app() -> Iterator[Application]:
     app = Application("test")
     app.commands_changed = Mock()
     app.commands.registered.connect(app.commands_changed)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
-import os
 
+import os
 import sys
-from typing import TYPE_CHECKING, Type
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -100,8 +100,8 @@ def test_app_context() -> None:
     assert isinstance(app.context, Context)
     Application.destroy("app1")
     assert app.context["is_windows"] == (os.name == "nt")
-    assert 'is_mac' in app.context
-    assert 'is_linux' in app.context
+    assert "is_mac" in app.context
+    assert "is_linux" in app.context
 
     app = Application("app2", context={"a": 1})
     assert isinstance(app.context, Context)


### PR DESCRIPTION
This PR adds an `Application.context` attribute.  It can serve as a natural place for applications to put a top level context (and, as usual, they can spawn children contexts with `context.new_child`).

it does not yet hook up context.changed signals to anything in the Qt backend.  mostly because I think more consideration of context "scoping" is necessary.  For example, it's not obvious that `app.context` is the "correct" context to pass to one of the `update_from_context` methods... it might be a more narrowly scoped child context provided by the user. 