### PR TITLE
fix: catch runtime error on QModelSubmenu cleanup

### DIFF
--- a/src/app_model/backends/qt/_qmenu.py
+++ b/src/app_model/backends/qt/_qmenu.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 from typing import (
     TYPE_CHECKING,
     Collection,
@@ -120,7 +121,10 @@ class QModelMenu(QMenu):
 
     def _on_registry_changed(self, changed_ids: Set[str]) -> None:
         if self._menu_id in changed_ids:
-            self.rebuild()
+            # if this (sub)menu has been removed from the registry,
+            # we may hit a RuntimeError when trying to rebuild it.
+            with contextlib.suppress(RuntimeError):
+                self.rebuild()
 
 
 class QModelSubmenu(QModelMenu):


### PR DESCRIPTION
This fixes #147 
There may be other/better ways to fix it.  Specifically, we could add a new `menus_removed` signal to the MenuRegistry, and emit that instead of `menu_changed` here: https://github.com/pyapp-kit/app-model/blob/0049cb81e3e7a6825f325320fb7fa28c5023b372/src/app_model/registries/_menus_reg.py#L71

but, until I'm sure that that doesn't have unintended side effects, this should at least catch the case of trying to rebuild a submenu that has just been disposed of.