### PR TITLE
docs: remove minify plugin

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,8 +26,6 @@ plugins:
   - literate-nav:
       nav_file: SUMMARY.txt
   - autorefs
-  - minify:
-      minify_html: true
   - mkdocstrings:
       handlers:
         python:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,6 @@ docs = [
     "mkdocs-literate-nav",
     "mkdocs-macros-plugin==1.0.5",
     "mkdocs-material==9.4.1",
-    "mkdocs-minify-plugin==0.7.1",
     "mkdocs==1.5.3",
     "mkdocstrings-python==1.7.3",
     "mkdocstrings==0.23.0",


### PR DESCRIPTION
not really necessary, and depends on an unmaintained htmlmin package