### PR TITLE
style: type cleanup/modernization

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,8 +26,6 @@ plugins:
   - literate-nav:
       nav_file: SUMMARY.txt
   - autorefs
-  - minify:
-      minify_html: true
   - mkdocstrings:
       handlers:
         python:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,6 @@ docs = [
     "mkdocs-literate-nav",
     "mkdocs-macros-plugin==1.0.5",
     "mkdocs-material==9.4.1",
-    "mkdocs-minify-plugin==0.7.1",
     "mkdocs==1.5.3",
     "mkdocstrings-python==1.7.3",
     "mkdocstrings==0.23.0",

--- a/src/app_model/_app.py
+++ b/src/app_model/_app.py
@@ -27,8 +27,7 @@ from .registries import (
 )
 
 if TYPE_CHECKING:
-    from .types import Action
-    from .types._constants import DisposeCallable
+    from .types import Action, DisposeCallable
 
 
 class Application:

--- a/src/app_model/registries/_keybindings_reg.py
+++ b/src/app_model/registries/_keybindings_reg.py
@@ -1,18 +1,17 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Callable, NamedTuple, Optional
+from typing import TYPE_CHECKING, Callable, NamedTuple
 
 from psygnal import Signal
 
-from app_model.types._keys import KeyBinding
+from app_model.types import KeyBinding
 
 if TYPE_CHECKING:
-    from typing import Iterator, List, TypeVar
+    from typing import Iterator, TypeVar
 
     from app_model import expressions
-    from app_model.types import KeyBindingRule
+    from app_model.types import DisposeCallable, KeyBindingRule
 
-    DisposeCallable = Callable[[], None]
     CommandDecorator = Callable[[Callable], Callable]
     CommandCallable = TypeVar("CommandCallable", bound=Callable)
 
@@ -23,7 +22,7 @@ class _RegisteredKeyBinding(NamedTuple):
     keybinding: KeyBinding  # the keycode to bind to
     command_id: str  # the command to run
     weight: int  # the weight of the binding, for prioritization
-    when: Optional[expressions.Expr] = None  # condition to enable keybinding
+    when: expressions.Expr | None = None  # condition to enable keybinding
 
 
 class KeyBindingsRegistry:
@@ -32,11 +31,11 @@ class KeyBindingsRegistry:
     registered = Signal()
 
     def __init__(self) -> None:
-        self._keybindings: List[_RegisteredKeyBinding] = []
+        self._keybindings: list[_RegisteredKeyBinding] = []
 
     def register_keybinding_rule(
         self, id: str, rule: KeyBindingRule
-    ) -> Optional[DisposeCallable]:
+    ) -> DisposeCallable | None:
         """Register a new keybinding rule.
 
         Parameters
@@ -75,7 +74,7 @@ class KeyBindingsRegistry:
         name = self.__class__.__name__
         return f"<{name} at {hex(id(self))} ({len(self._keybindings)} bindings)>"
 
-    def get_keybinding(self, key: str) -> Optional[_RegisteredKeyBinding]:
+    def get_keybinding(self, key: str) -> _RegisteredKeyBinding | None:
         """Return the first keybinding that matches the given command ID."""
         # TODO: improve me.
         return next(

--- a/src/app_model/registries/_menus_reg.py
+++ b/src/app_model/registries/_menus_reg.py
@@ -1,26 +1,13 @@
 from __future__ import annotations
 
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Dict,
-    Final,
-    Iterable,
-    Iterator,
-    List,
-    Optional,
-    Sequence,
-    Set,
-    Tuple,
-)
+from typing import TYPE_CHECKING, Any, Callable, Final, Iterable, Iterator, Sequence
 
 from psygnal import Signal
 
-from app_model.types import MenuItem, MenuOrSubmenu
+from app_model.types import MenuItem
 
 if TYPE_CHECKING:
-    from app_model.types._constants import DisposeCallable
+    from app_model.types import DisposeCallable, MenuOrSubmenu
 
 MenuId = str
 
@@ -32,10 +19,10 @@ class MenusRegistry:
     menus_changed = Signal(set)
 
     def __init__(self) -> None:
-        self._menu_items: Dict[MenuId, Dict[MenuOrSubmenu, None]] = {}
+        self._menu_items: dict[MenuId, dict[MenuOrSubmenu, None]] = {}
 
     def append_menu_items(
-        self, items: Sequence[Tuple[MenuId, MenuOrSubmenu]]
+        self, items: Sequence[tuple[MenuId, MenuOrSubmenu]]
     ) -> DisposeCallable:
         """Append menu items to the registry.
 
@@ -49,8 +36,8 @@ class MenusRegistry:
         DisposeCallable
             A function that can be called to unregister the menu items.
         """
-        changed_ids: Set[str] = set()
-        disposers: List[Callable[[], None]] = []
+        changed_ids: set[str] = set()
+        disposers: list[Callable[[], None]] = []
         for menu_id, item in items:
             item = MenuItem._validate(item)  # type: ignore
             menu_dict = self._menu_items.setdefault(menu_id, {})
@@ -77,13 +64,13 @@ class MenusRegistry:
 
     def __iter__(
         self,
-    ) -> Iterator[Tuple[MenuId, Iterable[MenuOrSubmenu]]]:
+    ) -> Iterator[tuple[MenuId, Iterable[MenuOrSubmenu]]]:
         yield from self._menu_items.items()
 
     def __contains__(self, id: object) -> bool:
         return id in self._menu_items
 
-    def get_menu(self, menu_id: MenuId) -> List[MenuOrSubmenu]:
+    def get_menu(self, menu_id: MenuId) -> list[MenuOrSubmenu]:
         """Return menu items for `menu_id`."""
         # using method rather than __getitem__ so that subclasses can use arguments
         return list(self._menu_items[menu_id])
@@ -95,10 +82,10 @@ class MenusRegistry:
     def __str__(self) -> str:
         return "\n".join(self._render())
 
-    def _render(self) -> List[str]:
+    def _render(self) -> list[str]:
         """Return registered menu items as lines of strings."""
         # this is mostly here as a debugging tool.  Can be removed or improved later.
-        lines: List[str] = []
+        lines: list[str] = []
 
         branch = "  ├──"
         for menu in self._menu_items:
@@ -121,7 +108,7 @@ class MenusRegistry:
             lines.append("")
         return lines
 
-    def iter_menu_groups(self, menu_id: MenuId) -> Iterator[List[MenuOrSubmenu]]:
+    def iter_menu_groups(self, menu_id: MenuId) -> Iterator[list[MenuOrSubmenu]]:
         """Iterate over menu groups for `menu_id`.
 
         Groups are broken into sections (lists of menu or submenu items) based on
@@ -142,12 +129,12 @@ class MenusRegistry:
 
 
 def _sort_groups(
-    items: List[MenuOrSubmenu],
+    items: list[MenuOrSubmenu],
     group_key: Callable = lambda x: "0000" if x == "navigation" else x or "",
     order_key: Callable = lambda x: getattr(x, "order", "") or 0,
-) -> Iterator[List[MenuOrSubmenu]]:
+) -> Iterator[list[MenuOrSubmenu]]:
     """Sort a list of menu items based on their .group and .order attributes."""
-    groups: dict[Optional[str], List[MenuOrSubmenu]] = {}
+    groups: dict[str | None, list[MenuOrSubmenu]] = {}
     for item in items:
         groups.setdefault(item.group, []).append(item)
 

--- a/src/app_model/registries/_register.py
+++ b/src/app_model/registries/_register.py
@@ -1,41 +1,42 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, TypeVar, overload
+from typing import TYPE_CHECKING, overload
 
 from app_model.types import Action, MenuItem
 
 if TYPE_CHECKING:
-    from typing import Any, Callable, List, Literal, Optional, Union
+    from typing import Any, Callable, Literal, TypeVar
 
-    from app_model import expressions
-    from app_model._app import Application
-    from app_model.types import IconOrDict, KeyBindingRuleOrDict, MenuRuleOrDict
-    from app_model.types._constants import DisposeCallable
+    from app_model import Application, expressions
+    from app_model.types import (
+        DisposeCallable,
+        IconOrDict,
+        KeyBindingRuleOrDict,
+        MenuRuleOrDict,
+    )
 
     CommandCallable = TypeVar("CommandCallable", bound=Callable[..., Any])
     CommandDecorator = Callable[[Callable], Callable]
 
 
 @overload
-def register_action(
-    app: Union[Application, str], id_or_action: Action
-) -> DisposeCallable:
+def register_action(app: Application | str, id_or_action: Action) -> DisposeCallable:
     ...
 
 
 @overload
 def register_action(
-    app: Union[Application, str],
+    app: Application | str,
     id_or_action: str,
     title: str,
     *,
     callback: Literal[None] = ...,
-    category: Optional[str] = ...,
-    tooltip: Optional[str] = ...,
-    icon: Optional[IconOrDict] = ...,
-    enablement: Optional[expressions.Expr] = ...,
-    menus: Optional[List[MenuRuleOrDict]] = ...,
-    keybindings: Optional[List[KeyBindingRuleOrDict]] = ...,
+    category: str | None = ...,
+    tooltip: str | None = ...,
+    icon: IconOrDict | None = ...,
+    enablement: expressions.Expr | None = ...,
+    menus: list[MenuRuleOrDict] | None = ...,
+    keybindings: list[KeyBindingRuleOrDict] | None = ...,
     palette: bool = True,
 ) -> CommandDecorator:
     ...
@@ -43,36 +44,36 @@ def register_action(
 
 @overload
 def register_action(
-    app: Union[Application, str],
+    app: Application | str,
     id_or_action: str,
     title: str,
     *,
     callback: CommandCallable,
-    category: Optional[str] = ...,
-    tooltip: Optional[str] = ...,
-    icon: Optional[IconOrDict] = ...,
-    enablement: Optional[expressions.Expr] = ...,
-    menus: Optional[List[MenuRuleOrDict]] = ...,
-    keybindings: Optional[List[KeyBindingRuleOrDict]] = ...,
+    category: str | None = ...,
+    tooltip: str | None = ...,
+    icon: IconOrDict | None = ...,
+    enablement: expressions.Expr | None = ...,
+    menus: list[MenuRuleOrDict] | None = ...,
+    keybindings: list[KeyBindingRuleOrDict] | None = ...,
     palette: bool = True,
 ) -> DisposeCallable:
     ...
 
 
 def register_action(
-    app: Union[Application, str],
-    id_or_action: Union[str, Action],
-    title: Optional[str] = None,
+    app: Application | str,
+    id_or_action: str | Action,
+    title: str | None = None,
     *,
-    callback: Optional[CommandCallable] = None,
-    category: Optional[str] = None,
-    tooltip: Optional[str] = None,
-    icon: Optional[IconOrDict] = None,
-    enablement: Optional[expressions.Expr] = None,
-    menus: Optional[List[MenuRuleOrDict]] = None,
-    keybindings: Optional[List[KeyBindingRuleOrDict]] = None,
+    callback: CommandCallable | None = None,
+    category: str | None = None,
+    tooltip: str | None = None,
+    icon: IconOrDict | None = None,
+    enablement: expressions.Expr | None = None,
+    menus: list[MenuRuleOrDict] | None = None,
+    keybindings: list[KeyBindingRuleOrDict] | None = None,
     palette: bool = True,
-) -> Union[CommandDecorator, DisposeCallable]:
+) -> CommandDecorator | DisposeCallable:
     """Register an action.
 
     An Action is the "complete" representation of a command.  The command is the
@@ -99,22 +100,22 @@ def register_action(
 
     Parameters
     ----------
-    app: Union[Application, str]
+    app: Application | str
         The app in which to register the action. If a string, the app is retrieved
         or created as necessary using `Application.get_or_create(app)`.
     id_or_action : Union[CommandId, Action]
         Either a complete Action object or a string id of the command being registered.
         If an `Action` object is provided, then all other arguments are ignored.
-    title : Optional[str]
+    title : str | None
         Title by which the command is represented in the UI. Required when
         `id_or_action` is a string.
     callback : Optional[CommandHandler]
         Callable object that executes this command, by default None. If not provided,
         a decorator is returned that can be used to decorate a function that executes
         this action.
-    category : Optional[str]
+    category : str | None
         Category string by which the command may be grouped in the UI, by default None
-    tooltip : Optional[str]
+    tooltip : str | None
         Tooltip to show when hovered., by default None
     icon : Optional[Icon]
         :class:`~app_model._types.Icon` used to represent this command,
@@ -122,10 +123,10 @@ def register_action(
     enablement : Optional[context.Expr]
         Condition which must be true to enable the command in in the UI,
         by default None
-    menus : Optional[List[MenuRuleOrDict]]
+    menus : list[MenuRuleOrDict] | None
         :class:`~app_model._types.MenuRule` or `dicts` containing menu
         placements for this action, by default None
-    keybindings : Optional[List[KeyBindingRuleOrDict]]
+    keybindings : list[KeyBindingRuleOrDict] | None
         :class:`~app_model._types.KeyBindingRule` or `dicts` containing
         default keybindings for this action, by default None
     palette : bool
@@ -133,7 +134,7 @@ def register_action(
 
     Returns
     -------
-    Union[CommandDecorator, DisposeCallable]
+    -------Union | CommandDecorator, isposeCallable]
         If `run` is not provided, then a decorator is returned.
         If `run` is provided, or `id_or_action` is an `Action` object, then a function
         that may be used to unregister the action is returned.
@@ -167,9 +168,8 @@ def register_action(
 
 
 def _register_action_str(
-    app: Union[Application, str],
-    **kwargs: Any,
-) -> Union[CommandDecorator, DisposeCallable]:
+    app: Application | str, **kwargs: Any
+) -> CommandDecorator | DisposeCallable:
     """Create and register an Action with a string id and title.
 
     Helper for `register_action()`.
@@ -190,10 +190,7 @@ def _register_action_str(
     return decorator
 
 
-def _register_action_obj(
-    app: Union[Application, str],
-    action: Action,
-) -> DisposeCallable:
+def _register_action_obj(app: Application | str, action: Action) -> DisposeCallable:
     """Register an Action object. Return a function that unregisters the action.
 
     Helper for `register_action()`.

--- a/src/app_model/types/__init__.py
+++ b/src/app_model/types/__init__.py
@@ -1,8 +1,10 @@
 """App-model types."""
+from typing import TYPE_CHECKING
+
 from ._action import Action
 from ._command_rule import CommandRule, ToggleRule
-from ._icon import Icon, IconOrDict
-from ._keybinding_rule import KeyBindingRule, KeyBindingRuleDict, KeyBindingRuleOrDict
+from ._icon import Icon
+from ._keybinding_rule import KeyBindingRule
 from ._keys import (
     KeyBinding,
     KeyChord,
@@ -12,35 +14,35 @@ from ._keys import (
     SimpleKeyBinding,
     StandardKeyBinding,
 )
-from ._menu_rule import (
-    MenuItem,
-    MenuItemBase,
-    MenuOrSubmenu,
-    MenuRule,
-    MenuRuleDict,
-    MenuRuleOrDict,
-    SubmenuItem,
-)
+from ._menu_rule import MenuItem, MenuItemBase, MenuRule, SubmenuItem
+
+if TYPE_CHECKING:
+    from typing import Callable, TypeAlias
+
+    from ._icon import IconOrDict as IconOrDict
+    from ._keybinding_rule import KeyBindingRuleDict as KeyBindingRuleDict
+    from ._keybinding_rule import KeyBindingRuleOrDict as KeyBindingRuleOrDict
+    from ._menu_rule import MenuOrSubmenu as MenuOrSubmenu
+    from ._menu_rule import MenuRuleDict as MenuRuleDict
+    from ._menu_rule import MenuRuleOrDict as MenuRuleOrDict
+
+    # function that can be called without arguments to dispose of a resource
+    DisposeCallable: TypeAlias = Callable[[], None]
+
 
 __all__ = [
     "Action",
     "CommandRule",
     "Icon",
-    "IconOrDict",
     "KeyBinding",
     "KeyBindingRule",
-    "KeyBindingRuleDict",
-    "KeyBindingRuleOrDict",
     "KeyChord",
     "KeyCode",
     "KeyCombo",
     "KeyMod",
     "MenuItem",
     "MenuItemBase",
-    "MenuOrSubmenu",
     "MenuRule",
-    "MenuRuleDict",
-    "MenuRuleOrDict",
     "ScanCode",
     "SimpleKeyBinding",
     "StandardKeyBinding",

--- a/src/app_model/types/_constants.py
+++ b/src/app_model/types/_constants.py
@@ -1,9 +1,6 @@
 import os
 import sys
 from enum import Enum
-from typing import Callable
-
-DisposeCallable = Callable[[], None]
 
 
 class OperatingSystem(Enum):


### PR DESCRIPTION
this hides a couple typing-only objects behind type_checking clauses (so they're not part of the public imports). and modernizes a few modules