### PR TITLE
feat: export register_action function at top level

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,6 +31,7 @@ plugins:
         python:
           import:
             - https://docs.python.org/3/objects.inv
+            - https://ino.readthedocs.io/en/latest/objects.inv
           options:
             extensions:
               - griffe_fieldz

--- a/src/app_model/__init__.py
+++ b/src/app_model/__init__.py
@@ -8,6 +8,7 @@ except PackageNotFoundError:  # pragma: no cover
     __version__ = "uninstalled"
 
 from ._app import Application
+from .registries._register import register_action
 from .types import Action
 
-__all__ = ["__version__", "Application", "Action"]
+__all__ = ["__version__", "Application", "Action", "register_action"]

--- a/src/app_model/expressions/_expressions.py
+++ b/src/app_model/expressions/_expressions.py
@@ -79,7 +79,7 @@ def safe_eval(expr: str | bool | Expr, context: Mapping | None = None) -> Any:
     ----------
     expr : str | bool | Expr
         Expression to evaluate. If `expr` is a string, it is parsed into an
-        :class:`Expr` instance. If a `bool`, it is returned directly.
+        `Expr` instance. If a `bool`, it is returned directly.
     context : Mapping | None
         Context (mapping of names to objects) to evaluate the expression in.
     """
@@ -427,7 +427,7 @@ class BoolOp(Expr[T], ast.BoolOp):
     with the same operator, such as a or b or c, are collapsed into one node
     with several values.
 
-    This doesn't include `not`, which is a :class:`UnaryOp`.
+    This doesn't include `not`, which is a `UnaryOp`.
     """
 
     def __init__(
@@ -462,7 +462,7 @@ class IfExp(Expr, ast.IfExp):
 
 
 class ExprTransformer(ast.NodeTransformer):
-    """Transformer that converts an ast.expr into an :class:`Expr`.
+    """Transformer that converts an ast.expr into an `Expr`.
 
     Examples
     --------
@@ -519,7 +519,7 @@ class ExprTransformer(ast.NodeTransformer):
 
 
 class _ExprSerializer(ast.NodeVisitor):
-    """Serializes an :class:`Expr` into a string.
+    """Serializes an `Expr` into a string.
 
     Examples
     --------

--- a/src/app_model/registries/_register.py
+++ b/src/app_model/registries/_register.py
@@ -120,11 +120,11 @@ def register_action(
         Condition which must be true to enable the command in in the UI,
         by default None
     menus : list[MenuRuleOrDict] | None
-        [`MenuRule`][app_model.types.MenuRule] or `dicts` containing menu
+        List of [`MenuRule`][app_model.types.MenuRule] or kwarg `dicts` containing menu
         placements for this action, by default None
     keybindings : list[KeyBindingRuleOrDict] | None
-        [`KeyBindingRule`][app_model.types.KeyBindingRule] or `dicts` containing
-        default keybindings for this action, by default None
+        List of [`KeyBindingRule`][app_model.types.KeyBindingRule] or kwargs `dicts`
+        containing default keybindings for this action, by default None
     palette : bool
         Whether to adds this command to the Command Palette, by default True
 
@@ -246,10 +246,14 @@ def _register_action_str(
     corresponding registries. Otherwise a decorator returned that can be used
     to decorate the callable that executes the action.
     """
-    if callable(kwargs.get("callback")):
+    if kwargs.get("callback") is not None:
         return _register_action_obj(app, Action(**kwargs))
 
     def decorator(command: CommandCallable, **k: Any) -> CommandCallable:
+        if not callable(command):
+            raise TypeError(
+                "@register_action decorator must be passed a callable object"
+            )
         _register_action_obj(app, Action(**{**kwargs, **k, "callback": command}))
         return command
 

--- a/src/app_model/types/_keys/_keybindings.py
+++ b/src/app_model/types/_keys/_keybindings.py
@@ -140,7 +140,8 @@ class KeyBinding:
     """KeyBinding.  May be a multi-part "Chord" (e.g. 'Ctrl+K Ctrl+C').
 
     This is the primary representation of a fully resolved keybinding. For consistency
-    in the downstream API, it should  be preferred to :class:`SimplyKeyBinding`, even
+    in the downstream API, it should be preferred to
+    [`SimpleKeyBinding`][app_model.types.SimpleKeyBinding], even
     when there is only a single part in the keybinding (i.e. when it is not a chord.)
 
     Chords (two separate keypress actions) are expressed as a string by separating


### PR DESCRIPTION
This adds the functional form of `register_action` (the one that supports decorator usage) as a top level export.

It also adds the full overload to the `Application.register_action` method.  This isn't technically adding a new form or new functionality, just exposing it