### PR TITLE
fix: handle qmods like QT5 for pyside6 not 6.4

### DIFF
--- a/src/app_model/backends/qt/_qkeymap.py
+++ b/src/app_model/backends/qt/_qkeymap.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 
 import operator
 from functools import reduce
+
 from typing import TYPE_CHECKING, Mapping, MutableMapping
 
+from qtpy import API, QT_VERSION
 from qtpy.QtCore import QCoreApplication, Qt
 from qtpy.QtGui import QKeySequence
 
@@ -79,7 +81,7 @@ else:
         return int(out)
 
 
-if QT6:
+if QT6 and not (API == "pyside6" and int(QT_VERSION[2]) < 4):
 
     def _get_qmods(key: QKeyCombination) -> Qt.KeyboardModifier:
         return key.keyboardModifiers()

--- a/src/app_model/backends/qt/_qkeymap.py
+++ b/src/app_model/backends/qt/_qkeymap.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import operator
 from functools import reduce
-
 from typing import TYPE_CHECKING, Mapping, MutableMapping
 
 from qtpy import API, QT_VERSION


### PR DESCRIPTION
We're trying to Goldilocks a pyside6 version for napari tests.
Recently (https://github.com/napari/napari/pull/6738) when testing with pyside6 6.3.1, we got this failure:
https://github.com/napari/napari/actions/runs/8303510051/job/22727974608?pr=6738#step:12:209

```
Traceback (most recent call last):
    File "/home/runner/work/napari/napari/napari/_qt/widgets/qt_keyboard_settings.py", line 685, in keyPressEvent
      kb = qkeysequence2modelkeybinding(event_keyseq)
    File "/home/runner/work/napari/napari/.tox/py39-linux-pyside6-cov/lib/python3.9/site-packages/app_model/backends/qt/_qkeymap.py", line 316, in qkeysequence2modelkeybinding
      parts = [SimpleKeyBinding.from_int(qkeycombo2modelkey(x)) for x in iter(key)]
    File "/home/runner/work/napari/napari/.tox/py39-linux-pyside6-cov/lib/python3.9/site-packages/app_model/backends/qt/_qkeymap.py", line 316, in <listcomp>
      parts = [SimpleKeyBinding.from_int(qkeycombo2modelkey(x)) for x in iter(key)]
    File "/home/runner/work/napari/napari/.tox/py39-linux-pyside6-cov/lib/python3.9/site-packages/app_model/backends/qt/_qkeymap.py", line 308, in qkeycombo2modelkey
      qmods = _get_qmods(key)
    File "/home/runner/work/napari/napari/.tox/py39-linux-pyside6-cov/lib/python3.9/site-packages/app_model/backends/qt/_qkeymap.py", line 85, in _get_qmods
      return key.keyboardModifiers()
  AttributeError: 'int' object has no attribute 'keyboardModifiers'
```



In this PR, for versions of pyside6 before 6.4, just use the QT5 handling.
I tested locally with pyside 6.3.1, and latest, as well as pyqt6 6.3.1 and latest.