### PR TITLE
fix: Do not use lambda in QMenuItemAction.destroyed callback

### DIFF
--- a/src/app_model/backends/qt/_qaction.py
+++ b/src/app_model/backends/qt/_qaction.py
@@ -150,9 +150,6 @@ class QMenuItemAction(QCommandRuleAction):
     def _cache_key(app: Application, menu_item: MenuItem) -> tuple[int, int]:
         return (id(app), hash(menu_item))
 
-    def _remove_from_cache(self) -> None:
-        cache_key = QMenuItemAction._cache_key(self._app, self._menu_item)
-        QMenuItemAction._cache.pop(cache_key, None)
 
     @classmethod
     def create(
@@ -180,8 +177,6 @@ class QMenuItemAction(QCommandRuleAction):
             return res
 
         cls._cache[cache_key] = obj = cls(menu_item, app, parent)
-        obj.destroyed.connect(obj._remove_from_cache)
-        app.destroyed.connect(obj._remove_from_cache)
         return obj
 
     def update_from_context(self, ctx: Mapping[str, object]) -> None:

--- a/src/app_model/backends/qt/_qaction.py
+++ b/src/app_model/backends/qt/_qaction.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 from typing import TYPE_CHECKING, ClassVar, Mapping
+from weakref import WeakValueDictionary
 
 from app_model import Application
 from app_model.expressions import Expr
@@ -130,7 +131,7 @@ class QMenuItemAction(QCommandRuleAction):
         Optional parent widget, by default None
     """
 
-    _cache: ClassVar[dict[tuple[int, int], QMenuItemAction]] = {}
+    _cache: ClassVar[dict[tuple[int, int], QMenuItemAction]] = WeakValueDictionary()
 
     def __init__(
         self,

--- a/src/app_model/backends/qt/_qaction.py
+++ b/src/app_model/backends/qt/_qaction.py
@@ -157,12 +157,16 @@ class QMenuItemAction(QCommandRuleAction):
             super().__init__(menu_item.command, app, parent)
             self._menu_item = menu_item
             key = (id(self._app), hash(menu_item))
-            self.destroyed.connect(lambda: QMenuItemAction._cache.pop(key, None))
-            self._app.destroyed.connect(lambda: QMenuItemAction._cache.pop(key, None))
+            self.destroyed.connect(self._remove_from_cache)
+            self._app.destroyed.connect(self._remove_from_cache)
             self._initialized = True
 
         with contextlib.suppress(NameError):
             self.update_from_context(self._app.context)
+
+    def _remove_from_cache(self) -> None:
+        key = (id(self._app), hash(self._menu_item))
+        QMenuItemAction._cache.pop(key, None)
 
     def update_from_context(self, ctx: Mapping[str, object]) -> None:
         """Update the enabled/visible state of this menu item from `ctx`."""

--- a/src/app_model/backends/qt/_qaction.py
+++ b/src/app_model/backends/qt/_qaction.py
@@ -156,7 +156,7 @@ class QMenuItemAction(QCommandRuleAction):
         if not initialized:
             super().__init__(menu_item.command, app, parent)
             self._menu_item = menu_item
-            key = (id(self._app), hash(menu_item))
+            (id(self._app), hash(menu_item))
             self.destroyed.connect(self._remove_from_cache)
             self._app.destroyed.connect(self._remove_from_cache)
             self._initialized = True

--- a/src/app_model/backends/qt/_qaction.py
+++ b/src/app_model/backends/qt/_qaction.py
@@ -131,7 +131,9 @@ class QMenuItemAction(QCommandRuleAction):
         Optional parent widget, by default None
     """
 
-    _cache: ClassVar[dict[tuple[int, int], QMenuItemAction]] = WeakValueDictionary()
+    _cache: ClassVar[WeakValueDictionary[tuple[int, int], QMenuItemAction]] = (
+        WeakValueDictionary()
+    )
 
     def __init__(
         self,

--- a/src/app_model/backends/qt/_qaction.py
+++ b/src/app_model/backends/qt/_qaction.py
@@ -173,7 +173,9 @@ class QMenuItemAction(QCommandRuleAction):
         app = Application.get_or_create(app) if isinstance(app, str) else app
         cache_key = QMenuItemAction._cache_key(app, menu_item)
         if cache_key in cls._cache:
-            return cls._cache[cache_key]
+            res = cls._cache[cache_key]
+            res.setParent(parent)
+            return res
 
         cls._cache[cache_key] = obj = cls(menu_item, app, parent)
         obj.destroyed.connect(obj._remove_from_cache)

--- a/src/app_model/backends/qt/_qaction.py
+++ b/src/app_model/backends/qt/_qaction.py
@@ -150,7 +150,6 @@ class QMenuItemAction(QCommandRuleAction):
     def _cache_key(app: Application, menu_item: MenuItem) -> tuple[int, int]:
         return (id(app), hash(menu_item))
 
-
     @classmethod
     def create(
         cls,

--- a/src/app_model/backends/qt/_qmenu.py
+++ b/src/app_model/backends/qt/_qmenu.py
@@ -317,7 +317,7 @@ def _rebuild(
                     submenu = QModelSubmenu(item, app, parent=menu)
                     cast("QMenu", menu).addMenu(submenu)
             elif item.command.id not in _exclude:
-                action = QMenuItemAction.create(item, app=app)
+                action = QMenuItemAction.create(item, app=app, parent=menu)
                 menu.addAction(action)
         if n < n_groups - 1:
             menu.addSeparator()

--- a/src/app_model/backends/qt/_qmenu.py
+++ b/src/app_model/backends/qt/_qmenu.py
@@ -242,6 +242,7 @@ class QModelToolBar(QToolBar):
             include_submenus=include_submenus,
             exclude=self._exclude if exclude is None else exclude,
         )
+        self.rebuilt.emit()
 
     def _disconnect(self) -> None:
         self._app.menus.menus_changed.disconnect(self._on_registry_changed)
@@ -317,7 +318,7 @@ def _rebuild(
                     submenu = QModelSubmenu(item, app, parent=menu)
                     cast("QMenu", menu).addMenu(submenu)
             elif item.command.id not in _exclude:
-                action = QMenuItemAction(item, app=app, parent=menu)
+                action = QMenuItemAction.create(item, app=app)
                 menu.addAction(action)
         if n < n_groups - 1:
             menu.addSeparator()

--- a/src/app_model/backends/qt/_qmenu.py
+++ b/src/app_model/backends/qt/_qmenu.py
@@ -242,7 +242,6 @@ class QModelToolBar(QToolBar):
             include_submenus=include_submenus,
             exclude=self._exclude if exclude is None else exclude,
         )
-        self.rebuilt.emit()
 
     def _disconnect(self) -> None:
         self._app.menus.menus_changed.disconnect(self._on_registry_changed)

--- a/src/app_model/backends/qt/_qmenu.py
+++ b/src/app_model/backends/qt/_qmenu.py
@@ -305,7 +305,10 @@ def _rebuild(
     exclude: Collection[str] | None = None,
 ) -> None:
     """Rebuild menu by looking up `menu` in `Application`'s menu_registry."""
-    menu.clear()
+    actions = menu.actions()
+    for action in actions:
+        menu.removeAction(action)
+
     _exclude = exclude or set()
 
     groups = list(app.menus.iter_menu_groups(menu_id))

--- a/tests/test_qt/test_qactions.py
+++ b/tests/test_qt/test_qactions.py
@@ -13,8 +13,8 @@ def test_cache_qaction(qapp, full_app: "FullApp") -> None:
     action = next(
         i for k, items in full_app.menus for i in items if isinstance(i, MenuItem)
     )
-    a1 = QMenuItemAction(action, full_app)
-    a2 = QMenuItemAction(action, full_app)
+    a1 = QMenuItemAction.create(action, full_app)
+    a2 = QMenuItemAction.create(action, full_app)
     assert a1 is a2
     assert repr(a1).startswith("QMenuItemAction")
 


### PR DESCRIPTION
In napari tests I got segfaults, after local debugs it points to lambda that are modified in this PR. 

In general, using the method is safer, as qt will not try to trigger the method of destroyed objects. 