### PR TITLE
feat: Allow passing bound parameters `QModelMenu`

### DIFF
--- a/src/app_model/backends/qt/_qaction.py
+++ b/src/app_model/backends/qt/_qaction.py
@@ -154,8 +154,8 @@ class QMenuItemAction(QCommandRuleAction):
         sig = _resolve_sig_or_inform(
             callback,
             localns=self._app._injection_store.namespace,
-            on_unresolved_required_args=False,
-            on_unannotated_required_args=False,
+            on_unresolved_required_args="ignore",
+            on_unannotated_required_args="ignore",
             guess_self=False,
         )
         if sig is None:

--- a/src/app_model/backends/qt/_qmenu.py
+++ b/src/app_model/backends/qt/_qmenu.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import contextlib
-from typing import TYPE_CHECKING, Collection, Iterable, Mapping, Sequence, cast
+from typing import TYPE_CHECKING, Any, Collection, Iterable, Mapping, Sequence, cast
 
 from qtpy.QtWidgets import QMenu, QMenuBar, QToolBar
 
@@ -33,6 +33,9 @@ class QModelMenu(QMenu):
         Optional title for the menu, by default None
     parent : QWidget | None
         Optional parent widget, by default None
+    bound_params : Collection[Any] | None
+        Objects to be passed to `Action` callbacks with matching parameter annotation.
+        By default None.
     """
 
     def __init__(
@@ -41,6 +44,7 @@ class QModelMenu(QMenu):
         app: Application | str,
         title: str | None = None,
         parent: QWidget | None = None,
+        bound_params: Collection[Any] | None = None,
     ):
         QMenu.__init__(self, parent)
 
@@ -54,6 +58,12 @@ class QModelMenu(QMenu):
         self._app.menus.menus_changed.connect(self._on_registry_changed)
         self.destroyed.connect(self._disconnect)
         # ----------------------
+
+        _bound_params: dict[type, Any] = dict()
+        if bound_params:
+            for obj in bound_params:
+                _bound_params[type(obj)] = obj
+        self._bound_params = _bound_params
 
         if title is not None:
             self.setTitle(title)


### PR DESCRIPTION
WIP: appreciate input on whether I'm on the right track.

Attempt at #176

Allow 'binding' of objects to `QModelMenu` that will be passed to action callbacks if the type annotation matches (inspired by `Store.inject` from `in-n-out`).
Reimplements `_on_triggered` of `QMenuItemAction` as suggested by @Czaki.

Bound objects passed as kwarg to callback via `CommandsRegistry.execute_command` `kwargs` param. The problem with this though is that these kwargs are passed after we run `run_injected`:

https://github.com/pyapp-kit/app-model/blob/a0c33c36dcf9dd2cc9bfd70ab5c4440c74e0f8b2/src/app_model/registries/_commands_reg.py#L181-L192

 In `run_injected` we give precedence to caller provided args/kwargs but AFAICT this cannot be done with kwargs passed via `execute_command`. Also I think (?) we have the problem that `execute_command(kwarg)` could be providing a kwarg that was already provided by `run_injected`? I am not sure how this parameter was meant to be used originally @tlambert03 ?

Edit: TODO I think I'll want to check if the bound obj is a weakref.

cc @DragaDoncila