### PR TITLE
feat: give registries more control over registration of actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,14 +15,14 @@ concurrency:
 
 jobs:
   test:
-    uses: pyapp-kit/workflows/.github/workflows/test-pyrepo.yml@v1
+    uses: pyapp-kit/workflows/.github/workflows/test-pyrepo.yml@v2
     secrets: inherit
     with:
       os: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}
       pip-post-installs: ${{ matrix.pydantic }}
       pip-install-pre-release: ${{ github.event_name == 'schedule' }}
-      report-failures: ${{ github.event_name == 'schedule' }}
+      coverage-upload: artifact
     strategy:
       fail-fast: false
       matrix:
@@ -47,7 +47,7 @@ jobs:
             pydantic: "'pydantic<2'"
 
   test-qt:
-    uses: pyapp-kit/workflows/.github/workflows/test-pyrepo.yml@v1
+    uses: pyapp-kit/workflows/.github/workflows/test-pyrepo.yml@v2
     secrets: inherit
     with:
       qt: ${{ matrix.qt }}
@@ -55,7 +55,7 @@ jobs:
       python-version: ${{ matrix.python-version }}
       extras: test-qt
       pip-install-pre-release: ${{ github.event_name == 'schedule' }}
-      report-failures: ${{ github.event_name == 'schedule' }}
+      coverage-upload: artifact
     strategy:
       fail-fast: false
       matrix:
@@ -69,7 +69,6 @@ jobs:
           - python-version: "3.10"
             os: "ubuntu-latest"
             qt: "PySide2~=5.15.0"
-
           - python-version: "3.10"
             os: "ubuntu-latest"
             qt: "PyQt6~=6.2.0"
@@ -85,11 +84,9 @@ jobs:
           - python-version: "3.11"
             os: "ubuntu-latest"
             qt: "PySide6~=6.6.0"
-          # not working until pyqt6-qt is fixed
-          # - python-version: "3.11"
-          #   os: "ubuntu-latest"
-          #   qt: "PyQt6~=6.6.0"
-
+          - python-version: "3.11"
+            os: "ubuntu-latest"
+            qt: pyqt6
           - python-version: "3.10"
             os: "windows-latest"
             qt: "PySide2"
@@ -97,8 +94,14 @@ jobs:
             os: "macos-13"
             qt: "PySide2"
 
+  upload_coverage:
+    if: always()
+    needs: [test, test-qt]
+    uses: pyapp-kit/workflows/.github/workflows/upload-coverage.yml@v2
+    secrets: inherit
+
   test_napari:
-    uses: pyapp-kit/workflows/.github/workflows/test-dependents.yml@v1
+    uses: pyapp-kit/workflows/.github/workflows/test-dependents.yml@v2
     with:
       dependency-repo: napari/napari
       dependency-ref: ${{ matrix.napari-version }}
@@ -106,7 +109,7 @@ jobs:
       qt: ${{ matrix.qt }}
       pytest-args: 'napari/_qt/_qapp_model napari/_app_model napari/utils/_tests/test_key_bindings.py -k "not async and not qt_dims_2"'
       python-version: "3.10"
-      post-install-cmd: "pip install lxml_html_clean"  # fix for napari v0.4.19
+      post-install-cmd: "pip install lxml_html_clean" # fix for napari v0.4.19
     strategy:
       fail-fast: false
       matrix:

--- a/src/app_model/registries/__init__.py
+++ b/src/app_model/registries/__init__.py
@@ -1,6 +1,6 @@
 """App-model registries, such as menus, keybindings, commands."""
 
-from ._commands_reg import CommandsRegistry
+from ._commands_reg import CommandsRegistry, RegisteredCommand
 from ._keybindings_reg import KeyBindingsRegistry
 from ._menus_reg import MenusRegistry
 from ._register import register_action
@@ -10,4 +10,5 @@ __all__ = [
     "KeyBindingsRegistry",
     "MenusRegistry",
     "register_action",
+    "RegisteredCommand",
 ]

--- a/src/app_model/registries/_commands_reg.py
+++ b/src/app_model/registries/_commands_reg.py
@@ -11,7 +11,7 @@ from psygnal import Signal
 if TYPE_CHECKING:
     from typing_extensions import ParamSpec
 
-    from app_model.types import DisposeCallable, Action
+    from app_model.types import Action, DisposeCallable
 
     P = ParamSpec("P")
 else:
@@ -90,9 +90,7 @@ class CommandsRegistry:
         self._injection_store = injection_store
         self._raise_synchronous_exceptions = raise_synchronous_exceptions
 
-    def register_action(
-        self, action: Action
-    ) -> DisposeCallable:
+    def register_action(self, action: Action) -> DisposeCallable:
         """Register an Action object.
 
         This is a convenience method that registers the action's callback

--- a/src/app_model/registries/_commands_reg.py
+++ b/src/app_model/registries/_commands_reg.py
@@ -31,8 +31,8 @@ class RegisteredCommand(Generic[P, R]):
     Used internally by the CommandsRegistry.
 
     This helper class allows us to cache the dependency-injected variant of the
-    command. As usual with `cached_property`, the cache can be cleard by deleting
-    the attribute: `del cmd.run_injected`
+    command, so that type resolution and dependency injection is performed only
+    once.
     """
 
     __slots__ = (

--- a/src/app_model/registries/_commands_reg.py
+++ b/src/app_model/registries/_commands_reg.py
@@ -63,9 +63,7 @@ class RegisteredCommand(Generic[P, R]):
     def __setattr__(self, name: str, value: Any) -> None:
         """Object is immutable after initialization."""
         if getattr(self, "_initialized", False):
-            raise AttributeError(
-                f"Cannot set attribute {name!r} on {self.__class__.__name__} instance"
-            )
+            raise AttributeError("RegisteredCommand object is immutable.")
         super().__setattr__(name, value)
 
     @property

--- a/src/app_model/registries/_commands_reg.py
+++ b/src/app_model/registries/_commands_reg.py
@@ -11,7 +11,7 @@ from psygnal import Signal
 if TYPE_CHECKING:
     from typing_extensions import ParamSpec
 
-    from app_model.types import DisposeCallable
+    from app_model.types import DisposeCallable, Action
 
     P = ParamSpec("P")
 else:
@@ -89,6 +89,26 @@ class CommandsRegistry:
         self._commands: dict[str, _RegisteredCommand] = {}
         self._injection_store = injection_store
         self._raise_synchronous_exceptions = raise_synchronous_exceptions
+
+    def register_action(
+        self, action: Action
+    ) -> DisposeCallable:
+        """Register an Action object.
+
+        This is a convenience method that registers the action's callback
+        with the action's ID and title using `register_command`.
+
+        Parameters
+        ----------
+        action: Action
+            Action to register
+
+        Returns
+        -------
+        DisposeCallable
+            A function that can be called to unregister the action.
+        """
+        return self.register_command(action.id, action.callback, action.title)
 
     def register_command(
         self, id: str, callback: Callable[P, R] | str, title: str

--- a/src/app_model/registries/_commands_reg.py
+++ b/src/app_model/registries/_commands_reg.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from concurrent.futures import Future, ThreadPoolExecutor
-from functools import cached_property
 from typing import TYPE_CHECKING, Any, Callable, Generic, Iterator, TypeVar, cast
 
 from in_n_out import Store
@@ -26,14 +25,25 @@ else:
 R = TypeVar("R")
 
 
-class _RegisteredCommand(Generic[P, R]):
+class RegisteredCommand(Generic[P, R]):
     """Small object to represent a command in the CommandsRegistry.
 
-    Only used internally by the CommandsRegistry.
+    Used internally by the CommandsRegistry.
+
     This helper class allows us to cache the dependency-injected variant of the
     command. As usual with `cached_property`, the cache can be cleard by deleting
     the attribute: `del cmd.run_injected`
     """
+
+    __slots__ = (
+        "id",
+        "callback",
+        "title",
+        "_resolved_callback",
+        "_injection_store",
+        "_injected_callback",
+        "_initialized",
+    )
 
     def __init__(
         self,
@@ -45,35 +55,57 @@ class _RegisteredCommand(Generic[P, R]):
         self.id = id
         self.callback = callback
         self.title = title
-        self._resolved_callback = callback if callable(callback) else None
         self._injection_store: Store = store or Store.get_store()
+        self._resolved_callback = callback if callable(callback) else None
+        self._injected_callback: Callable[P, R] | None = None
+        self._initialized = True
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        """Object is immutable after initialization."""
+        if getattr(self, "_initialized", False):
+            raise AttributeError(
+                f"Cannot set attribute {name!r} on {self.__class__.__name__} instance"
+            )
+        super().__setattr__(name, value)
 
     @property
     def resolved_callback(self) -> Callable[P, R]:
+        """Return the resolved command callback.
+
+        This property is cached, so the callback types are only resolved once.
+        """
         if self._resolved_callback is None:
             from app_model.types._utils import import_python_name
 
             try:
-                self._resolved_callback = import_python_name(str(self.callback))
+                cb = import_python_name(str(self.callback))
             except ImportError as e:
-                self._resolved_callback = cast(Callable[P, R], lambda *a, **k: None)
+                object.__setattr__(self, "_resolved_callback", lambda *a, **k: None)
                 raise type(e)(
                     f"Command pointer {self.callback!r} registered for Command "
                     f"{self.id!r} was not importable: {e}"
                 ) from e
 
-            if not callable(self._resolved_callback):
+            if not callable(cb):
                 # don't try to import again, just create a no-op
-                self._resolved_callback = cast(Callable[P, R], lambda *a, **k: None)
+                object.__setattr__(self, "_resolved_callback", lambda *a, **k: None)
                 raise TypeError(
                     f"Command pointer {self.callback!r} registered for Command "
                     f"{self.id!r} did not resolve to a callble object."
                 )
-        return self._resolved_callback
+            object.__setattr__(self, "_resolved_callback", cb)
+        return cast("Callable[P, R]", self._resolved_callback)
 
-    @cached_property
+    @property
     def run_injected(self) -> Callable[P, R]:
-        return self._injection_store.inject(self.resolved_callback, processors=True)
+        """Return the command callback with dependencies injected.
+
+        This property is cached, so the injected version is only created once.
+        """
+        if self._injected_callback is None:
+            cb = self._injection_store.inject(self.resolved_callback, processors=True)
+            object.__setattr__(self, "_injected_callback", cb)
+        return cast("Callable[P, R]", self._injected_callback)
 
 
 class CommandsRegistry:
@@ -86,7 +118,7 @@ class CommandsRegistry:
         injection_store: Store | None = None,
         raise_synchronous_exceptions: bool = False,
     ) -> None:
-        self._commands: dict[str, _RegisteredCommand] = {}
+        self._commands: dict[str, RegisteredCommand] = {}
         self._injection_store = injection_store
         self._raise_synchronous_exceptions = raise_synchronous_exceptions
 
@@ -133,7 +165,7 @@ class CommandsRegistry:
                 f"{self._commands[id].callback!r} (new callback: {callback!r})"
             )
 
-        cmd = _RegisteredCommand(id, callback, title, self._injection_store)
+        cmd = RegisteredCommand(id, callback, title, self._injection_store)
         self._commands[id] = cmd
 
         def _dispose() -> None:
@@ -142,7 +174,7 @@ class CommandsRegistry:
         self.registered.emit(id)
         return _dispose
 
-    def __iter__(self) -> Iterator[tuple[str, _RegisteredCommand]]:
+    def __iter__(self) -> Iterator[tuple[str, RegisteredCommand]]:
         yield from self._commands.items()
 
     def __len__(self) -> int:
@@ -155,7 +187,7 @@ class CommandsRegistry:
         name = self.__class__.__name__
         return f"<{name} at {hex(id(self))} ({len(self._commands)} commands)>"
 
-    def __getitem__(self, id: str) -> _RegisteredCommand:
+    def __getitem__(self, id: str) -> RegisteredCommand:
         """Retrieve commands registered under a given ID."""
         if id not in self._commands:
             raise KeyError(f"Command {id!r} not registered")

--- a/src/app_model/registries/_keybindings_reg.py
+++ b/src/app_model/registries/_keybindings_reg.py
@@ -65,7 +65,7 @@ class KeyBindingsRegistry:
             if d := self.register_keybinding_rule(action.id, _keyb):
                 disposers.append(d)
 
-        if not disposers:
+        if not disposers:  # pragma: no cover
             return None
 
         def _dispose() -> None:

--- a/src/app_model/registries/_menus_reg.py
+++ b/src/app_model/registries/_menus_reg.py
@@ -52,7 +52,7 @@ class MenusRegistry:
             disp = self.append_menu_items([(self.COMMAND_PALETTE_ID, menu_item)])
             disposers.append(disp)
 
-        if not disposers:
+        if not disposers:  # pragma: no cover
             return None
 
         def _dispose() -> None:

--- a/src/app_model/registries/_menus_reg.py
+++ b/src/app_model/registries/_menus_reg.py
@@ -35,9 +35,6 @@ class MenusRegistry:
             A function that can be called to unregister the menu items. If no
             menu items were registered, returns `None`.
         """
-        if not (menu_rules := action.menus):
-            return None
-
         disposers: list[Callable[[], None]] = []
         disp1 = self.append_menu_items(
             (
@@ -46,7 +43,7 @@ class MenusRegistry:
                     command=action, when=rule.when, group=rule.group, order=rule.order
                 ),
             )
-            for rule in menu_rules
+            for rule in action.menus or ()
         )
         disposers.append(disp1)
 

--- a/src/app_model/registries/_menus_reg.py
+++ b/src/app_model/registries/_menus_reg.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Callable, Final, Iterable, Iterator, Sequence
+from typing import TYPE_CHECKING, Any, Callable, Final, Iterable, Iterator
 
 from psygnal import Signal
 
 from app_model.types import MenuItem
 
 if TYPE_CHECKING:
-    from app_model.types import DisposeCallable, MenuOrSubmenu
+    from app_model.types import Action, DisposeCallable, MenuOrSubmenu
 
 MenuId = str
 
@@ -21,14 +21,57 @@ class MenusRegistry:
     def __init__(self) -> None:
         self._menu_items: dict[MenuId, dict[MenuOrSubmenu, None]] = {}
 
+    def append_action_menus(self, action: Action) -> DisposeCallable | None:
+        """Append all MenuRule items declared in `action.menus`.
+
+        Parameters
+        ----------
+        action : Action
+            The action containing menus to append.
+
+        Returns
+        -------
+        DisposeCallable | None
+            A function that can be called to unregister the menu items. If no
+            menu items were registered, returns `None`.
+        """
+        if not (menu_rules := action.menus):
+            return None
+
+        disposers: list[Callable[[], None]] = []
+        disp1 = self.append_menu_items(
+            (
+                rule.id,
+                MenuItem(
+                    command=action, when=rule.when, group=rule.group, order=rule.order
+                ),
+            )
+            for rule in menu_rules
+        )
+        disposers.append(disp1)
+
+        if action.palette:
+            menu_item = MenuItem(command=action, when=action.enablement)
+            disp = self.append_menu_items([(self.COMMAND_PALETTE_ID, menu_item)])
+            disposers.append(disp)
+
+        if not disposers:
+            return None
+
+        def _dispose() -> None:
+            for disposer in disposers:
+                disposer()
+
+        return _dispose
+
     def append_menu_items(
-        self, items: Sequence[tuple[MenuId, MenuOrSubmenu]]
+        self, items: Iterable[tuple[MenuId, MenuOrSubmenu]]
     ) -> DisposeCallable:
         """Append menu items to the registry.
 
         Parameters
         ----------
-        items : Sequence[Tuple[str, MenuOrSubmenu]]
+        items : Iterable[Tuple[str, MenuOrSubmenu]]
             Items to append.
 
         Returns

--- a/src/app_model/registries/_register.py
+++ b/src/app_model/registries/_register.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, overload
 
-from app_model.types import Action, MenuItem
+from app_model.types import Action
 
 if TYPE_CHECKING:
     from typing import Any, Callable, Literal, TypeVar

--- a/tests/test_command_registry.py
+++ b/tests/test_command_registry.py
@@ -1,6 +1,6 @@
 import pytest
 
-from app_model.registries import CommandsRegistry
+from app_model.registries import CommandsRegistry, RegisteredCommand
 
 
 def raise_exc() -> None:
@@ -39,3 +39,12 @@ def test_commands_raises() -> None:
 
     with pytest.raises(RuntimeError, match="boom"):
         reg.execute_command("my.id")
+
+    cmd = reg["my.id"]
+    assert isinstance(cmd, RegisteredCommand)
+    assert cmd.title == "My Title"
+
+    with pytest.raises(AttributeError, match="immutable"):
+        cmd.title = "New Title"
+
+    assert cmd.title == "My Title"

--- a/tests/test_command_registry.py
+++ b/tests/test_command_registry.py
@@ -9,18 +9,19 @@ def raise_exc() -> None:
 
 def test_commands_registry() -> None:
     reg = CommandsRegistry()
-    reg.register_command("my.id", lambda: 42, "My Title")
+    id1 = "my.id"
+    reg.register_command(id1, lambda: 42, "My Title")
     assert "(1 commands)" in repr(reg)
-    assert "my.id" in str(reg)
-    assert "my.id" in reg
+    assert id1 in str(reg)
+    assert id1 in reg
     with pytest.raises(KeyError, match="my.id2"):
         reg["my.id2"]
 
     with pytest.raises(ValueError, match="Command 'my.id' already registered"):
-        reg.register_command("my.id", lambda: 42, "My Title")
+        reg.register_command(id1, lambda: 42, "My Title")
 
-    assert reg.execute_command("my.id", execute_asynchronously=True).result() == 42
-    assert reg.execute_command("my.id", execute_asynchronously=False).result() == 42
+    assert reg.execute_command(id1, execute_asynchronously=True).result() == 42
+    assert reg.execute_command(id1, execute_asynchronously=False).result() == 42
 
     reg.register_command("my.id2", raise_exc, "My Title 2")
     future_async = reg.execute_command("my.id2", execute_asynchronously=True)
@@ -35,16 +36,18 @@ def test_commands_registry() -> None:
 def test_commands_raises() -> None:
     reg = CommandsRegistry(raise_synchronous_exceptions=True)
 
-    reg.register_command("my.id", raise_exc, "My Title")
+    id_ = "my.id"
+    title = "My Title"
+    reg.register_command(id_, raise_exc, title)
 
     with pytest.raises(RuntimeError, match="boom"):
-        reg.execute_command("my.id")
+        reg.execute_command(id_)
 
-    cmd = reg["my.id"]
+    cmd = reg[id_]
     assert isinstance(cmd, RegisteredCommand)
-    assert cmd.title == "My Title"
+    assert cmd.title == title
 
     with pytest.raises(AttributeError, match="immutable"):
         cmd.title = "New Title"
 
-    assert cmd.title == "My Title"
+    assert cmd.title == title


### PR DESCRIPTION
This PR moves some of the logic in the `register_action` function into methods on the registries themselves.  This will make it easier for custom subclasses of registries to control exactly how they register actions.  
It has some relatively inconsequential other stuff, like making `RegisteredCommand` immutable and public