### PR TITLE
feat: allow callable values in contexts

### DIFF
--- a/src/app_model/expressions/_expressions.py
+++ b/src/app_model/expressions/_expressions.py
@@ -151,9 +151,6 @@ class Expr(ast.AST, Generic[T]):
     >>> new_expr.eval(dict(v2="hello!", myvar=8))
     'hello!'
 
-    you can also use keyword arguments.  This is *slightly* slower
-    >>> new_expr.eval(v2="hello!", myvar=4)
-
     serialize
     >>> str(new_expr)
     'myvar > 5 and v2'
@@ -184,33 +181,27 @@ class Expr(ast.AST, Generic[T]):
         self._names = set(_iter_names(self))
         self.eval = self.eval_with_callables  # type: ignore
 
-    def eval(
-        self, context: Mapping[str, object] | None = None, **ctx_kwargs: object
-    ) -> T:
-        """Evaluate this expression with names in `context`."""
+    def eval(self, context: Mapping[str, object] | None = None) -> T:
+        """Evaluate this expression with names in `context`.
+
+        Parameters
+        ----------
+        context : Mapping[str, object] | None
+            Mapping of names to objects to evaluate the expression with.
+        """
         # will have been replaced in __init__
         raise NotImplementedError("This method should have been replaced.")
 
-    def eval_no_callables(
-        self, context: Mapping[str, object] | None = None, **ctx_kwargs: object
-    ) -> T:
+    def eval_no_callables(self, context: Mapping[str, object] | None = None) -> T:
         """Evaluate this expression with names in `context`."""
         if context is None:
-            context = ctx_kwargs
-        elif ctx_kwargs:
-            context = {**context, **ctx_kwargs}
+            context = {}
         return self._eval(context)
 
-    def eval_with_callables(
-        self, context: Mapping[str, object] | None = None, **ctx_kwargs: object
-    ) -> T:
+    def eval_with_callables(self, context: Mapping[str, object] | None = None) -> T:
         """Evaluate this expression with names in `context`, allowing callables."""
         if context is None:
-            context = ctx_kwargs
-        elif ctx_kwargs:
-            context = {**context, **ctx_kwargs}
-        if context is None:
-            return self._eval(context)
+            return self._eval({})
 
         ctx = {}
         for name in self._names:

--- a/src/app_model/expressions/_expressions.py
+++ b/src/app_model/expressions/_expressions.py
@@ -201,6 +201,11 @@ class Expr(ast.AST, Generic[T]):
         for name in self._names:
             if name in context:
                 ctx[name] = val() if callable(val := context[name]) else val
+            else:
+                miss = {k for k in self._names if k not in context}
+                raise NameError(
+                    f"Names required to eval this expression are missing: {miss}"
+                )
         return self.eval_no_callables(ctx)
 
     @classmethod

--- a/src/app_model/expressions/_expressions.py
+++ b/src/app_model/expressions/_expressions.py
@@ -181,6 +181,7 @@ class Expr(ast.AST, Generic[T]):
         if type(self).__name__ == "Expr":
             raise RuntimeError("Don't instantiate Expr. Use `Expr.parse`")
         super().__init__(*args, **kwargs)
+        self.eval = self.eval_with_callables  # type: ignore[method-assign]
         self._recompile()
 
     def _recompile(self) -> None:

--- a/src/app_model/expressions/_expressions.py
+++ b/src/app_model/expressions/_expressions.py
@@ -229,7 +229,11 @@ class Expr(ast.AST, Generic[T]):
     def _missing_names_error(self, context: Mapping[str, object]) -> NameError:
         """More informative error message when names are missing."""
         miss = {k for k in self._names if k not in context}
-        return NameError(f"Names required to eval this expression are missing: {miss}")
+        num_keys = len(context)
+        return NameError(
+            f"Names required to eval expression '{self}' are missing: {miss}. "
+            f"Context has {num_keys} keys."
+        )
 
     @classmethod
     def parse(cls, expr: str) -> Expr:

--- a/src/app_model/expressions/_expressions.py
+++ b/src/app_model/expressions/_expressions.py
@@ -201,16 +201,6 @@ class Expr(ast.AST, Generic[T]):
             context = {**context, **ctx_kwargs}
         return self._eval(context)
 
-    def _eval(self, context: Mapping[str, object]) -> T:
-        """Evaluate this expression using `context`, providing useful error."""
-        try:
-            return eval(self._code, {}, context)  # type: ignore
-        except NameError as e:
-            miss = {k for k in self._names if k not in context}
-            raise NameError(
-                f"Names required to eval this expression are missing: {miss}"
-            ) from e
-
     def eval_with_callables(
         self, context: Mapping[str, object] | None = None, **ctx_kwargs: object
     ) -> T:
@@ -232,6 +222,16 @@ class Expr(ast.AST, Generic[T]):
                     f"Names required to eval this expression are missing: {miss}"
                 )
         return self.eval_no_callables(ctx)
+
+    def _eval(self, context: Mapping[str, object]) -> T:
+        """Evaluate this expression using `context`, providing useful error."""
+        try:
+            return eval(self._code, {}, context)  # type: ignore
+        except NameError as e:
+            miss = {k for k in self._names if k not in context}
+            raise NameError(
+                f"Names required to eval this expression are missing: {miss}"
+            ) from e
 
     @classmethod
     def parse(cls, expr: str) -> Expr:

--- a/tests/test_context/test_expressions.py
+++ b/tests/test_context/test_expressions.py
@@ -236,12 +236,6 @@ def test_safe_eval():
         safe_eval("{1,2,3}")
 
 
-def test_eval_kwargs():
-    expr = parse_expression("a + b")
-    assert expr.eval(a=1, b=2) == 3
-    assert expr.eval({"a": 2}, b=2) == 4
-
-
 @pytest.mark.parametrize("expr", GOOD_EXPRESSIONS)
 def test_hash(expr):
     assert isinstance(hash(parse_expression(expr)), int)

--- a/tests/test_qt/test_qmenu.py
+++ b/tests/test_qt/test_qmenu.py
@@ -61,7 +61,9 @@ def test_menu(
     assert redo_action.isEnabled()
 
     # useful error when we forget a required name
-    with pytest.raises(NameError, match="Names required to eval this expression"):
+    with pytest.raises(
+        NameError, match="Names required to eval expression 'allow_undo_redo'"
+    ):
         menu.update_from_context({})
 
     menu._disconnect()


### PR DESCRIPTION
same as https://github.com/pyapp-kit/app-model/pull/198
(creating a new PR from a different branch cause i accidentally had that one on my main)


This implements the idea I was mentioning in [#196 ](https://github.com/pyapp-kit/app-model/issues/196#issuecomment-2114978480), wherein a context *value* is allowed to be a callable (that takes no arguments).

```python
In [2]: from app_model.expressions import parse_expression

In [3]: expr = parse_expression("x < 10")

In [4]: expr.eval_callable_context({'x': lambda: 42})
Out[4]: False
```

this would combine nicely with `lru_cache`, where the *value* of a context-key is an lru_cache decorated function, and some event just invalidates the cache rather than calculates the value