### PR TITLE
feat: Add `filter_keybinding` to `KeyBindingRegistry`

### DIFF
--- a/src/app_model/registries/_keybindings_reg.py
+++ b/src/app_model/registries/_keybindings_reg.py
@@ -31,8 +31,8 @@ class KeyBindingsRegistry:
     Attributes
     ----------
     filter_keybinding : Callable[[KeyBinding], str] | None
-        Optional function for filtering out invalid `KeyBinding`s.
-        Callable should return a error message string if `KeyBinding` is invalid
+        Function for filtering out invalid `KeyBinding`s.
+        Callable should return an error message string if `KeyBinding` is invalid
         or empty string if `KeyBinding` is valid.
     """
 

--- a/src/app_model/registries/_keybindings_reg.py
+++ b/src/app_model/registries/_keybindings_reg.py
@@ -86,11 +86,10 @@ class KeyBindingsRegistry:
                 _keyb = keyb
 
             try:
-                d = self.register_keybinding_rule(action.id, _keyb)
+                if d := self.register_keybinding_rule(action.id, _keyb):
+                    disposers.append(d)
             except ValueError as e:
                 msg.append(str(e))
-            else:
-                disposers.append(d)
         if msg:
             raise ValueError(
                 "The following keybindings were not valid:\n" + "\n".join(msg)

--- a/tests/test_registries.py
+++ b/tests/test_registries.py
@@ -25,7 +25,6 @@ def test_register_keybinding_rule_filter() -> None:
     reg = KeyBindingsRegistry()
 
     def filter_fun(kb: KeyBinding) -> str | None:
-        print(f"is mod: {kb.part0.is_modifier_key()}")
         if kb.part0.is_modifier_key():
             return "modifier only sequences not allowed"
         return ""

--- a/tests/test_registries.py
+++ b/tests/test_registries.py
@@ -1,7 +1,7 @@
 import pytest
 
 from app_model.registries import KeyBindingsRegistry, MenusRegistry
-from app_model.types import KeyBinding, KeyBindingRule, KeyMod, KeyCode, MenuItem
+from app_model.types import KeyBinding, KeyBindingRule, KeyCode, KeyMod, MenuItem
 
 
 def test_menus_registry() -> None:
@@ -25,7 +25,7 @@ def test_register_keybinding_rule_filter() -> None:
     reg = KeyBindingsRegistry()
 
     def filter_fun(kb: KeyBinding) -> str | None:
-        print(f'is mod: {kb.part0.is_modifier_key()}')
+        print(f"is mod: {kb.part0.is_modifier_key()}")
         if kb.part0.is_modifier_key():
             return "modifier only sequences not allowed"
         return ""
@@ -33,8 +33,8 @@ def test_register_keybinding_rule_filter() -> None:
     reg.filter_keybinding = filter_fun
     # Valid keybinding
     kb = KeyBindingRule(primary=KeyMod.CtrlCmd | KeyCode.KeyO)
-    reg.register_keybinding_rule('test', kb)
+    reg.register_keybinding_rule("test", kb)
     # Invalid keybinding
     kb = KeyBindingRule(primary=KeyMod.CtrlCmd | KeyMod.Shift)
-    with pytest.raises(ValueError, match = "modifier only"):
-        reg.register_keybinding_rule('test', kb)
+    with pytest.raises(ValueError, match="modifier only"):
+        reg.register_keybinding_rule("test", kb)

--- a/tests/test_registries.py
+++ b/tests/test_registries.py
@@ -72,8 +72,8 @@ def test_register_keybinding_rule_filter() -> None:
             "",
         ),
         (
-            [{"primary": KeyMod.CtrlCmd}, {"primary": KeyMod.Shift}],
-            r"Ctrl\+: modifier only sequences not allowed\nShift\+: modifier",
+            [{"primary": KeyMod.Alt}, {"primary": KeyMod.Shift}],
+            r"Alt\+: modifier only sequences not allowed\nShift\+: modifier",
         ),
     ],
 )

--- a/tests/test_registries.py
+++ b/tests/test_registries.py
@@ -1,7 +1,14 @@
 import pytest
 
 from app_model.registries import KeyBindingsRegistry, MenusRegistry
-from app_model.types import Action, KeyBinding, KeyBindingRule, KeyCode, KeyMod, MenuItem
+from app_model.types import (
+    Action,
+    KeyBinding,
+    KeyBindingRule,
+    KeyCode,
+    KeyMod,
+    MenuItem,
+)
 
 
 def test_menus_registry() -> None:
@@ -24,7 +31,7 @@ def test_register_keybinding_rule_filter_type() -> None:
     """Check `_filter_keybinding` type checking when setting."""
     reg = KeyBindingsRegistry()
     with pytest.raises(TypeError, match="'filter_keybinding' must be a callable"):
-        reg.filter_keybinding = 'string'
+        reg.filter_keybinding = "string"
 
 
 def _filter_fun(kb: KeyBinding) -> str:
@@ -54,17 +61,22 @@ def test_register_keybinding_rule_filter() -> None:
         reg.register_keybinding_rule("test", kb)
 
 
-@pytest.mark.parametrize("kb, msg", [
-    (
-        [{"primary": KeyMod.CtrlCmd | KeyCode.KeyA},
-         {"primary": KeyMod.Shift | KeyCode.KeyC}],
-        ""
-    ),
-    (
-        [{"primary": KeyMod.CtrlCmd}, {"primary": KeyMod.Shift}],
-        r"Ctrl\+: modifier only sequences not allowed\nShift\+: modifier",
-    ),
-])
+@pytest.mark.parametrize(
+    "kb, msg",
+    [
+        (
+            [
+                {"primary": KeyMod.CtrlCmd | KeyCode.KeyA},
+                {"primary": KeyMod.Shift | KeyCode.KeyC},
+            ],
+            "",
+        ),
+        (
+            [{"primary": KeyMod.CtrlCmd}, {"primary": KeyMod.Shift}],
+            r"Ctrl\+: modifier only sequences not allowed\nShift\+: modifier",
+        ),
+    ],
+)
 def test_register_action_keybindings_filter(kb, msg) -> None:
     """Check `filter_keybinding` in `register_action_keybindings`."""
     reg = KeyBindingsRegistry()

--- a/tests/test_registries.py
+++ b/tests/test_registries.py
@@ -56,8 +56,8 @@ def test_register_keybinding_rule_filter() -> None:
     kb = KeyBindingRule(primary=KeyMod.CtrlCmd | KeyCode.KeyO)
     reg.register_keybinding_rule("test", kb)
     # Invalid keybinding
-    kb = KeyBindingRule(primary=KeyMod.CtrlCmd | KeyMod.Shift)
-    with pytest.raises(ValueError, match=r"Ctrl\+Shift\+: modifier only"):
+    kb = KeyBindingRule(primary=KeyMod.Alt)
+    with pytest.raises(ValueError, match=r"Alt\+: modifier only"):
         reg.register_keybinding_rule("test", kb)
 
 

--- a/tests/test_registries.py
+++ b/tests/test_registries.py
@@ -24,7 +24,7 @@ def test_register_keybinding_rule_filter() -> None:
     """Check `filter_keybinding` in `register_keybinding_rule`."""
     reg = KeyBindingsRegistry()
 
-    def filter_fun(kb: KeyBinding) -> str | None:
+    def filter_fun(kb: KeyBinding) -> str:
         if kb.part0.is_modifier_key():
             return "modifier only sequences not allowed"
         return ""


### PR DESCRIPTION
closes #206

Adds a `filter_keybinding` (not 100% on name) attr to `KeyBindingRegistry`, which takes `Callable[[KeyBinding], str]` - if str is empty the keybinding is valid otherwise error message str should be returned.

Just a start, happy to take any feedback.

Will update docs once code ready.