### PR TITLE
feat: Include command/control-0 for OriginalSize in StandardKeyBindings

### DIFF
--- a/src/app_model/types/_keys/_standard_bindings.py
+++ b/src/app_model/types/_keys/_standard_bindings.py
@@ -70,6 +70,7 @@ class StandardKeyBinding(Enum):
     Underline = auto()
     Undo = auto()
     WhatsThis = auto()
+    OriginalSize = auto()
     ZoomIn = auto()
     ZoomOut = auto()
 
@@ -148,6 +149,7 @@ _STANDARD_KEYS = [
     SK(StandardKeyBinding.Underline, KeyMod.CtrlCmd | KeyCode.KeyU),
     SK(StandardKeyBinding.Undo, KeyMod.CtrlCmd | KeyCode.KeyZ),
     SK(StandardKeyBinding.WhatsThis, KeyMod.Shift | KeyCode.F1),
+    SK(StandardKeyBinding.OriginalSize, KeyMod.CtrlCmd | KeyCode.Digit0),
     SK(StandardKeyBinding.ZoomIn, KeyMod.CtrlCmd | KeyCode.Equal),
     SK(StandardKeyBinding.ZoomOut, KeyMod.CtrlCmd | KeyCode.Minus),
 ]


### PR DESCRIPTION
I just discovered the very cool StandardKeyBindings while adding Zoom keybindings in napari.
In this PR I'm just adding the `command/control-0` to reset zoom as a standard keybinding, sometimes called OriginalSize (Qt), Actual Size (macOS), etc. but a consistent pattern on macOS and Windows and in Qt (https://doc.qt.io/qtcreator/creator-keyboard-shortcuts.html#image-viewer-shortcuts).