### PR TITLE
feat: add KeyCombo.Ctrl and KeybindingRule.to_keybinding

### DIFF
--- a/src/app_model/types/_constants.py
+++ b/src/app_model/types/_constants.py
@@ -26,18 +26,18 @@ class OperatingSystem(Enum):
 
     @property
     def is_windows(self) -> bool:
-        """Returns True if the current operating system is Windows."""
-        return _CURRENT == OperatingSystem.WINDOWS
+        """Returns True if this enum instance is Windows."""
+        return self == OperatingSystem.WINDOWS
 
     @property
     def is_linux(self) -> bool:
-        """Returns True if the current operating system is Linux."""
-        return _CURRENT == OperatingSystem.LINUX
+        """Returns True if this enum instance is Linux."""
+        return self == OperatingSystem.LINUX
 
     @property
     def is_mac(self) -> bool:
-        """Returns True if the current operating system is MacOS."""
-        return _CURRENT == OperatingSystem.MACOS
+        """Returns True if this enum instance is MacOS."""
+        return self == OperatingSystem.MACOS
 
 
 _CURRENT = OperatingSystem.UNKNOWN

--- a/src/app_model/types/_constants.py
+++ b/src/app_model/types/_constants.py
@@ -27,12 +27,12 @@ class OperatingSystem(Enum):
     @property
     def is_windows(self) -> bool:
         """Returns True if this enum instance is Windows."""
-        return self == OperatingSystem.WINDOWS
+        return self == OperatingSystem.WINDOWS  # pragma: no cover
 
     @property
     def is_linux(self) -> bool:
         """Returns True if this enum instance is Linux."""
-        return self == OperatingSystem.LINUX
+        return self == OperatingSystem.LINUX  # pragma: no cover
 
     @property
     def is_mac(self) -> bool:

--- a/src/app_model/types/_keybinding_rule.py
+++ b/src/app_model/types/_keybinding_rule.py
@@ -61,7 +61,7 @@ class KeyBindingRule(_BaseModel):
                 return KeyBinding.from_str(enc)
             else:
                 raise TypeError("invalid keybinding")  # pragma: no cover
-        raise ValueError("No keybinding for platform")
+        raise ValueError("No keybinding for platform")  # pragma: no cover
 
     def for_os(self, os: Optional[OperatingSystem] = None) -> Optional[KeyEncoding]:
         """Select the encoding for the given OS, or current OS if not specified."""

--- a/src/app_model/types/_keybinding_rule.py
+++ b/src/app_model/types/_keybinding_rule.py
@@ -51,7 +51,7 @@ class KeyBindingRule(_BaseModel):
     )
 
     def to_keybinding(
-        self, os: OperatingSystem | None = None
+        self, os: Optional[OperatingSystem] = None
     ) -> "Optional[KeyBinding]":
         if (enc := self.for_os(os)) is not None:
             if isinstance(enc, int):
@@ -62,7 +62,7 @@ class KeyBindingRule(_BaseModel):
                 raise TypeError("invalid keybinding")  # pragma: no cover
         raise ValueError("No keybinding for platform")
 
-    def for_os(self, os: OperatingSystem | None = None) -> Optional[KeyEncoding]:
+    def for_os(self, os: Optional[OperatingSystem] = None) -> Optional[KeyEncoding]:
         if os is None:
             os = OperatingSystem.current()
         enc = {

--- a/src/app_model/types/_keybinding_rule.py
+++ b/src/app_model/types/_keybinding_rule.py
@@ -3,6 +3,7 @@ from typing import Any, Callable, Optional, TypedDict, TypeVar, Union
 from pydantic_compat import PYDANTIC2, Field, model_validator
 
 from app_model import expressions
+from app_model.types._keys._keybindings import KeyBinding
 
 from ._base import _BaseModel
 from ._constants import KeyBindingSource, OperatingSystem
@@ -10,11 +11,6 @@ from ._keys import StandardKeyBinding
 
 KeyEncoding = Union[int, str]
 M = TypeVar("M")
-
-_OS = OperatingSystem.current()
-_WIN = _OS.is_windows
-_MAC = _OS.is_mac
-_LINUX = _OS.is_linux
 
 
 class KeyBindingRule(_BaseModel):
@@ -54,14 +50,29 @@ class KeyBindingRule(_BaseModel):
         description="Who registered the keybinding. Used to sort keybindings.",
     )
 
-    def _bind_to_current_platform(self) -> Optional[KeyEncoding]:
-        if _WIN and self.win:
-            return self.win
-        if _MAC and self.mac:
-            return self.mac
-        if _LINUX and self.linux:
-            return self.linux
-        return self.primary
+    def to_keybinding(
+        self, os: OperatingSystem | None = None
+    ) -> "Optional[KeyBinding]":
+        if (enc := self.for_os(os)) is not None:
+            if isinstance(enc, int):
+                return KeyBinding.from_int(enc, os=os)
+            elif isinstance(enc, str):
+                return KeyBinding.from_str(enc)
+            else:
+                raise TypeError("invalid keybinding")  # pragma: no cover
+        raise ValueError("No keybinding for platform")
+
+    def for_os(self, os: OperatingSystem | None = None) -> Optional[KeyEncoding]:
+        if os is None:
+            os = OperatingSystem.current()
+        enc = {
+            OperatingSystem.WINDOWS: self.win,
+            OperatingSystem.MACOS: self.mac,
+            OperatingSystem.LINUX: self.linux,
+        }[os]
+        if enc is None:
+            return self.primary
+        return enc
 
     # These methods are here to make KeyBindingRule work as a field
     # there are better ways to do this now with pydantic v2... but it still

--- a/src/app_model/types/_keybinding_rule.py
+++ b/src/app_model/types/_keybinding_rule.py
@@ -53,6 +53,7 @@ class KeyBindingRule(_BaseModel):
     def to_keybinding(
         self, os: Optional[OperatingSystem] = None
     ) -> "Optional[KeyBinding]":
+        """Return a keybinding for the given OS, or current OS if not specified."""
         if (enc := self.for_os(os)) is not None:
             if isinstance(enc, int):
                 return KeyBinding.from_int(enc, os=os)
@@ -63,6 +64,7 @@ class KeyBindingRule(_BaseModel):
         raise ValueError("No keybinding for platform")
 
     def for_os(self, os: Optional[OperatingSystem] = None) -> Optional[KeyEncoding]:
+        """Select the encoding for the given OS, or current OS if not specified."""
         if os is None:
             os = OperatingSystem.current()
         enc = {

--- a/src/app_model/types/_keys/_key_codes.py
+++ b/src/app_model/types/_keys/_key_codes.py
@@ -736,10 +736,14 @@ class KeyMod(IntFlag):
     """A Flag indicating keyboard modifiers."""
 
     NONE = 0
+
     CtrlCmd = 1 << 11  # command on a mac, control on windows
     Shift = 1 << 10  # shift key
     Alt = 1 << 9  # alt option
-    WinCtrl = 1 << 8  # meta key on windows, ctrl key on mac
+    WinCtrl = 1 << 8  # meta key on windows, control key on mac
+
+    Ctrl = 1 << 12  # control key, regardless of OS
+    Meta = 1 << 13  # command key on a mac, meta key on windows
 
     @overload  # type: ignore
     def __or__(self, other: "KeyMod") -> "KeyMod": ...

--- a/src/app_model/types/_keys/_keybindings.py
+++ b/src/app_model/types/_keys/_keybindings.py
@@ -80,15 +80,19 @@ class SimpleKeyBinding(BaseModel):
         cls, key_int: int, os: Optional[OperatingSystem] = None
     ) -> "SimpleKeyBinding":
         """Create a SimpleKeyBinding from an integer."""
-        ctrl_cmd = bool(key_int & KeyMod.CtrlCmd)
-        win_ctrl = bool(key_int & KeyMod.WinCtrl)
+        if os is None:
+            os = OperatingSystem.current()
+
         shift = bool(key_int & KeyMod.Shift)
         alt = bool(key_int & KeyMod.Alt)
-
-        os = OperatingSystem.current() if os is None else os
-        ctrl = win_ctrl if os.is_mac else ctrl_cmd
-        meta = ctrl_cmd if os.is_mac else win_ctrl
         key = key_int & 0x000000FF  # keycode mask
+
+        if os.is_mac:
+            ctrl = bool(key_int & KeyMod.WinCtrl) or bool(key_int & KeyMod.Ctrl)
+            meta = bool(key_int & KeyMod.CtrlCmd) or bool(key_int & KeyMod.Meta)
+        else:
+            ctrl = bool(key_int & KeyMod.CtrlCmd) or bool(key_int & KeyMod.Ctrl)
+            meta = bool(key_int & KeyMod.WinCtrl) or bool(key_int & KeyMod.Meta)
 
         return cls(ctrl=ctrl, shift=shift, alt=alt, meta=meta, key=key)
 
@@ -102,14 +106,15 @@ class SimpleKeyBinding(BaseModel):
         """Convert this SimpleKeyBinding to an integer representation."""
         os = OperatingSystem.current() if os is None else os
         mods: KeyMod = KeyMod.NONE
+        is_mac = os == OperatingSystem.MACOS
         if self.ctrl:
-            mods |= KeyMod.WinCtrl if os.is_mac else KeyMod.CtrlCmd
+            mods |= KeyMod.WinCtrl if is_mac else KeyMod.CtrlCmd
         if self.shift:
             mods |= KeyMod.Shift
         if self.alt:
             mods |= KeyMod.Alt
         if self.meta:
-            mods |= KeyMod.CtrlCmd if os.is_mac else KeyMod.WinCtrl
+            mods |= KeyMod.CtrlCmd if is_mac else KeyMod.WinCtrl
         return mods | (self.key or 0)
 
     def _mods2keycodes(self) -> list[KeyCode]:

--- a/tests/test_keybindings.py
+++ b/tests/test_keybindings.py
@@ -195,3 +195,43 @@ def test_standard_keybindings() -> None:
 
     m = M(key=StandardKeyBinding.Copy)
     assert m.key.primary == KeyMod.CtrlCmd | KeyCode.KeyC
+
+
+@pytest.mark.parametrize(
+    "enc, os, expect",
+    [
+        (KeyMod.CtrlCmd | KeyCode.KeyX, OperatingSystem.MACOS, "Cmd+X"),
+        (KeyMod.CtrlCmd | KeyCode.KeyX, OperatingSystem.WINDOWS, "Ctrl+X"),
+        (KeyMod.WinCtrl | KeyCode.KeyX, OperatingSystem.MACOS, "Control+X"),
+        (KeyMod.WinCtrl | KeyCode.KeyX, OperatingSystem.WINDOWS, "Win+X"),
+        (KeyMod.Ctrl | KeyCode.KeyX, OperatingSystem.MACOS, "Control+X"),
+        (KeyMod.Ctrl | KeyCode.KeyX, OperatingSystem.WINDOWS, "Ctrl+X"),
+        (KeyMod.Meta | KeyCode.KeyX, OperatingSystem.MACOS, "Cmd+X"),
+        (KeyMod.Meta | KeyCode.KeyX, OperatingSystem.WINDOWS, "Win+X"),
+        # careful, it can be a bit confusing to combine Ctrl | CtrlCmd
+        # it's not recommended
+        (
+            KeyMod.Ctrl | KeyMod.CtrlCmd | KeyCode.KeyX,
+            OperatingSystem.MACOS,
+            "Control+Cmd+X",
+        ),
+        (
+            KeyMod.Ctrl | KeyMod.CtrlCmd | KeyCode.KeyX,
+            OperatingSystem.WINDOWS,
+            "Ctrl+X",
+        ),
+        (
+            KeyMod.Meta | KeyMod.CtrlCmd | KeyCode.KeyX,
+            OperatingSystem.MACOS,
+            "Cmd+X",
+        ),
+        (
+            KeyMod.Meta | KeyMod.CtrlCmd | KeyCode.KeyX,
+            OperatingSystem.WINDOWS,
+            "Ctrl+Win+X",
+        ),
+    ],
+)
+def test_keymod_ctrl_meta(enc: int, os: OperatingSystem, expect: str) -> None:
+    rule = KeyBindingRule(primary=enc)
+    assert rule.to_keybinding(os=os).to_text(os=os, joinchar="+") == expect


### PR DESCRIPTION
closes #229

This PR adds two more KeyMods:  `KeyMod.Ctrl` and `KeyMod.Meta`

- CtrlCmd:   command on a mac, control on windows
- Shift:   shift key
- Alt:  alt/option key
- WinCtrl:  meta key on windows, control key on mac
- **Ctrl**:  control key, regardless of OS (NEW)
- **Meta**: command key on a mac, meta key on windows (NEW)

most of the time, you will want to use `CtrlCmd` and `WinCtrl`, since they do what is usually "expected" when the keycode is converted to a Keybinding object.   But in cases where you just always want the control key, or meta key, regardless of platform, the new codes can be used.  Note: it *can* be confusing if you combine `Ctrl` with `CtrlCmd` ... (it would be just ctrl on windows, but cmd+ctrl on macos) so it's definitely not recommended.  

It also adds some conveniences for debugging.  It adds a public `KeyBindingRule.to_keybinding` method that takes in an optional os.  so one can easily test how these things are resolved, on any platform

```python
from app_model.types import KeyBindingRule, KeyCode, KeyMod, OperatingSystem

rule = KeyBindingRule(primary=KeyMod.CtrlCmd | KeyCode.KeyX)
os = OperatingSystem.WINDOWS
print(rule.to_keybinding(os=os).to_text(os=os))
```