### PR TITLE
fix small typo in Getting Started doc

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -142,7 +142,7 @@ of:
   function at execution time, based on command definition return type annotations.
 
 See [`in-n-out` getting started](https://ino.readthedocs.io/en/latest/getting_started/)
-for more details on the use of providers/processos in the `Store`.
+for more details on the use of providers/processors in the `Store`.
 
 Here's a simple example.  Let's say an application has a `User` object with a `name()`
 method:


### PR DESCRIPTION
This is just a small typo fix. Thanks!