### PR TITLE
feat: allow explicit variable bound to be passed to Name

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,13 +5,13 @@ ci:
 
 repos:
   - repo: https://github.com/crate-ci/typos
-    rev: v1
+    rev: v1.31.1
     hooks:
       - id: typos
         args: []
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.4
+    rev: v0.11.7
     hooks:
       - id: ruff
         args: ["--fix", "--unsafe-fixes"]

--- a/src/app_model/expressions/_context_keys.py
+++ b/src/app_model/expressions/_context_keys.py
@@ -69,10 +69,6 @@ class ContextKey(Name, Generic[A, T]):
         Explicitly provide the `Name` string used when evaluating a context,
         by default the key will be taken as the attribute name to which this
         object is assigned as a class attribute:
-    bound : Any | None
-        The type of the variable represented by this name (i.e. the type to which this
-        name evaluates to when used in an expression). This is used to provide type
-        hints when evaluating the expression. If `None`, the type is not known.
 
     Examples
     --------

--- a/src/app_model/expressions/_context_keys.py
+++ b/src/app_model/expressions/_context_keys.py
@@ -69,6 +69,10 @@ class ContextKey(Name, Generic[A, T]):
         Explicitly provide the `Name` string used when evaluating a context,
         by default the key will be taken as the attribute name to which this
         object is assigned as a class attribute:
+    bound : Any | None
+        The type of the variable represented by this name (i.e. the type to which this
+        name evaluates to when used in an expression). This is used to provide type
+        hints when evaluating the expression. If `None`, the type is not known.
 
     Examples
     --------
@@ -97,7 +101,8 @@ class ContextKey(Name, Generic[A, T]):
         *,
         id: str = "",  # optional because of __set_name__
     ) -> None:
-        super().__init__(id or "")
+        bound = type(default_value) if default_value is not MISSING else None
+        super().__init__(id or "", bound=bound)
         self._default_value = default_value
         self._getter = getter
         self._description = description

--- a/src/app_model/types/__init__.py
+++ b/src/app_model/types/__init__.py
@@ -19,7 +19,9 @@ from ._keys import (
 from ._menu_rule import MenuItem, MenuItemBase, MenuRule, SubmenuItem
 
 if TYPE_CHECKING:
-    from typing import Callable, TypeAlias
+    from typing import Callable
+
+    from typing_extensions import TypeAlias
 
     from ._icon import IconOrDict as IconOrDict
     from ._keybinding_rule import KeyBindingRuleDict as KeyBindingRuleDict

--- a/tests/test_context/test_expressions.py
+++ b/tests/test_context/test_expressions.py
@@ -8,7 +8,8 @@ from app_model.expressions._expressions import _OPS, _iter_names
 
 
 def test_names():
-    assert Name("n").eval({"n": 5}) == 5
+    expr = Name("n", bound=int)
+    assert expr.eval({"n": 5}) == 5
 
     # currently, evaludating with a missing name is an error.
     with pytest.raises(NameError):


### PR DESCRIPTION
this allows for directly providing the type to which a Name expression evaluates to:

```python
from app_model.expressions import Name

is_running = Name("is_running", bound=bool)
reveal_type(is_running.eval())  # Revealed type is "builtins.bool"
```

also updates pre-commit