### PR TITLE
feat: add `registered_actions` to Application

### DIFF
--- a/src/app_model/registries/_register.py
+++ b/src/app_model/registries/_register.py
@@ -269,19 +269,4 @@ def _register_action_obj(app: Application | str, action: Action) -> DisposeCalla
     from app_model._app import Application
 
     app = app if isinstance(app, Application) else Application.get_or_create(app)
-
-    # commands
-    disposers = [app.commands.register_action(action)]
-    # menus
-    if dm := app.menus.append_action_menus(action):
-        disposers.append(dm)
-    # keybindings
-    if dk := app.keybindings.register_action_keybindings(action):
-        disposers.append(dk)
-
-    def _dispose() -> None:
-        for d in disposers:
-            d()
-
-    app._disposers.append((action.id, _dispose))
-    return _dispose
+    return app._register_action_obj(action)

--- a/src/app_model/types/__init__.py
+++ b/src/app_model/types/__init__.py
@@ -19,7 +19,9 @@ from ._keys import (
 from ._menu_rule import MenuItem, MenuItemBase, MenuRule, SubmenuItem
 
 if TYPE_CHECKING:
-    from typing import Callable, TypeAlias
+    from typing import Callable
+
+    from typing_extensions import TypeAlias
 
     from ._icon import IconOrDict as IconOrDict
     from ._keybinding_rule import KeyBindingRuleDict as KeyBindingRuleDict

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -8,6 +8,8 @@ import pytest
 
 from app_model import Application
 from app_model.expressions import Context
+from app_model.types import Action
+from app_model.types._menu_rule import MenuRule
 
 if TYPE_CHECKING:
     from conftest import FullApp
@@ -115,3 +117,18 @@ def test_app_context() -> None:
 
     with pytest.raises(TypeError, match="context must be a Context or MutableMapping"):
         Application("app4", context=1)  # type: ignore[arg-type]
+
+
+def test_register_actions() -> None:
+    app = Application("app5")
+    actions = app.registered_actions
+    assert not actions
+    dispose = app.register_action(
+        "my_action", title="My Action", callback=lambda: None, menus=["Window"]
+    )
+    assert "my_action" in actions
+    assert isinstance(action := actions["my_action"], Action)
+    assert action.menus == [MenuRule(id="Window")]
+    dispose()
+    assert "my_action" not in actions
+    assert not actions


### PR DESCRIPTION
This PR allows one to query all of the actions that have been registered.  Currently, because an action is ultimately a wrapper around commands, menu placements, and keybindings... the registered action gets broken up and contributed to each registry.  This PR just lets you remember how they all came in together.  It's an immutable mapping proxy.