### PR TITLE
feat: Update of shortcuts on menu rebuild

### DIFF
--- a/src/app_model/backends/qt/_qaction.py
+++ b/src/app_model/backends/qt/_qaction.py
@@ -95,6 +95,7 @@ class QCommandRuleAction(QCommandAction):
     ) -> None:
         super().__init__(command_rule.id, app, parent)
         self._cmd_rule = command_rule
+        self._tooltip = command_rule.tooltip or ""
         if use_short_title and command_rule.short_title:
             self.setText(command_rule.short_title)  # pragma: no cover
         else:
@@ -102,23 +103,18 @@ class QCommandRuleAction(QCommandAction):
         if command_rule.icon:
             self.setIcon(to_qicon(command_rule.icon))
         self.setIconVisibleInMenu(command_rule.icon_visible_in_menu)
-        if command_rule.tooltip:
-            self.setToolTip(command_rule.tooltip)
+        self.setToolTip(self._tooltip)
         if command_rule.status_tip:
             self.setStatusTip(command_rule.status_tip)
         if command_rule.toggled is not None:
             self.setCheckable(True)
             self._refresh()
-        tooltip_with_keybinding = (
-            f"{self.toolTip()} {self._keybinding_tooltip}".rstrip()
-        )
+        tooltip_with_keybinding = f"{self._tooltip} {self._keybinding_tooltip}".rstrip()
         self.setToolTip(tooltip_with_keybinding)
 
     def _update_keybinding(self) -> None:
         super()._update_keybinding()
-        tooltip_with_keybinding = (
-            f"{self.toolTip()} {self._keybinding_tooltip}".rstrip()
-        )
+        tooltip_with_keybinding = f"{self._tooltip} {self._keybinding_tooltip}".rstrip()
         self.setToolTip(tooltip_with_keybinding)
 
     def update_from_context(self, ctx: Mapping[str, object]) -> None:

--- a/src/app_model/registries/_keybindings_reg.py
+++ b/src/app_model/registries/_keybindings_reg.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from bisect import insort_left
 from collections import defaultdict
+from operator import attrgetter
 from typing import TYPE_CHECKING, Callable, NamedTuple
 
 from psygnal import Signal
@@ -195,7 +196,17 @@ class KeyBindingsRegistry:
         """Return the first keybinding that matches the given command ID."""
         # TODO: improve me.
         return next(
-            (entry for entry in self._keybindings if entry.command_id == command_id),
+            iter(
+                sorted(
+                    (
+                        entry
+                        for entry in self._keybindings
+                        if entry.command_id == command_id
+                    ),
+                    key=attrgetter("source"),
+                    reverse=True,
+                )
+            ),
             None,
         )
 

--- a/tests/test_qt/test_qactions.py
+++ b/tests/test_qt/test_qactions.py
@@ -18,7 +18,8 @@ if TYPE_CHECKING:
     from conftest import FullApp
 
 
-def test_cache_qaction(qapp, full_app: "FullApp") -> None:
+@pytest.mark.usefixtures("qapp")
+def test_cache_qaction(full_app: "FullApp") -> None:
     action = next(
         i for k, items in full_app.menus for i in items if isinstance(i, MenuItem)
     )
@@ -28,7 +29,8 @@ def test_cache_qaction(qapp, full_app: "FullApp") -> None:
     assert repr(a1).startswith("QMenuItemAction")
 
 
-def test_toggle_qaction(qapp, simple_app: "Application") -> None:
+@pytest.mark.usefixtures("qapp")
+def test_toggle_qaction(simple_app: "Application") -> None:
     mock = Mock()
     x = False
 
@@ -75,6 +77,7 @@ def test_icon_visible_in_menu(qapp, simple_app: "Application") -> None:
     assert not q_action.isIconVisibleInMenu()
 
 
+@pytest.mark.usefixtures("qapp")
 @pytest.mark.parametrize(
     ("tooltip", "expected_tooltip"),
     [
@@ -83,7 +86,7 @@ def test_icon_visible_in_menu(qapp, simple_app: "Application") -> None:
     ],
 )
 def test_tooltip(
-    qapp, simple_app: "Application", tooltip: str, expected_tooltip: str
+    simple_app: "Application", tooltip: str, expected_tooltip: str
 ) -> None:
     action = Action(
         id="test.tooltip", title="Test tooltip", tooltip=tooltip, callback=lambda: None
@@ -93,6 +96,7 @@ def test_tooltip(
     assert q_action.toolTip() == expected_tooltip
 
 
+@pytest.mark.usefixtures("qapp")
 @pytest.mark.parametrize(
     ("tooltip", "tooltip_with_keybinding", "tooltip_without_keybinding"),
     [
@@ -105,7 +109,6 @@ def test_tooltip(
     ],
 )
 def test_keybinding_in_tooltip(
-    qapp,
     simple_app: "Application",
     tooltip: str,
     tooltip_with_keybinding: str,

--- a/tests/test_qt/test_qactions.py
+++ b/tests/test_qt/test_qactions.py
@@ -130,3 +130,27 @@ def test_keybinding_in_tooltip(
     # check setting tooltip manually removes keybinding info
     q_action.setToolTip(tooltip)
     assert q_action.toolTip() == tooltip_without_keybinding
+
+
+@pytest.mark.usefixtures("qapp")
+def test_update_keybinding_in_tooltip(
+    simple_app: "Application",
+) -> None:
+    action = Action(
+        id="test.update.keybinding.tooltip",
+        title="Test update keybinding tooltip",
+        callback=lambda: None,
+        tooltip="Initial tooltip",
+        keybindings=[KeyBindingRule(primary=KeyCode.KeyK)],
+    )
+    simple_app.register_action(action)
+
+    q_action = QCommandRuleAction(action, simple_app)
+    assert q_action.toolTip() == "Initial tooltip (K)"
+
+    # Update the keybinding
+    simple_app.keybindings.register_keybinding_rule(
+        "test.update.keybinding.tooltip", KeyBindingRule(primary=KeyCode.KeyL)
+    )
+    q_action._update_keybinding()
+    assert q_action.toolTip() == "Initial tooltip (L)"

--- a/tests/test_qt/test_qactions.py
+++ b/tests/test_qt/test_qactions.py
@@ -8,6 +8,7 @@ from app_model.types import (
     Action,
     CommandRule,
     KeyBindingRule,
+    KeyBindingSource,
     KeyCode,
     MenuItem,
     ToggleRule,
@@ -150,7 +151,8 @@ def test_update_keybinding_in_tooltip(
 
     # Update the keybinding
     simple_app.keybindings.register_keybinding_rule(
-        "test.update.keybinding.tooltip", KeyBindingRule(primary=KeyCode.KeyL)
+        "test.update.keybinding.tooltip",
+        KeyBindingRule(primary=KeyCode.KeyL, source=KeyBindingSource.USER),
     )
     q_action._update_keybinding()
     assert q_action.toolTip() == "Initial tooltip (L)"


### PR DESCRIPTION
This PR adds updating of shortcuts on menu rebuild. 

This is required for full migration of the napari into app model

* Update shortcut on menu rebuild
* Update tooltip to reflect current shortcut 
* Add sorting of keybindings to prioritize user-defined over default ones
* Add a test checking if everything works as expected. 