### PR TITLE
chore: Pin `pytest-qt` on python 3.10 to fix pyside2 tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,8 @@ test = ["pytest>=7.0", "pytest-cov >=6.1"]
 test-qt = [
     { include-group = "test" },
     "app-model[qt]",
-    "pytest-qt >=4.3.0",
+    "pytest-qt >=4.3.0; python_version > '3.10'",
+    "pytest-qt ==4.4.0; python_version <= '3.10'",
     "fonticon-fontawesome6 >=6.4.0",
 ]
 dev = [


### PR DESCRIPTION
The pytest-qt 4.5.0 drops pyside2 support. 

I suggest using pytest-qt in version to 4.4.0 for python 3.10. 


As we merged PySide6 support in napari a short time ago, I expect to drop PySide2 in the following months. 