### PR TITLE
fix: themed color for icons

### DIFF
--- a/src/app_model/backends/qt/_util.py
+++ b/src/app_model/backends/qt/_util.py
@@ -15,7 +15,7 @@ def to_qicon(icon: Icon, theme: Literal["dark", "light"] = "dark") -> QIcon:
     """Create QIcon from Icon."""
     from superqt import QIconifyIcon, fonticon
 
-    color = 'white' if theme == 'dark' else 'black'
+    color = "white" if theme == "dark" else "black"
     if icn := getattr(icon, theme, ""):
         if icn.startswith("file://"):
             return QIcon(QUrl(icn).toLocalFile())

--- a/src/app_model/backends/qt/_util.py
+++ b/src/app_model/backends/qt/_util.py
@@ -15,11 +15,12 @@ def to_qicon(icon: Icon, theme: Literal["dark", "light"] = "dark") -> QIcon:
     """Create QIcon from Icon."""
     from superqt import QIconifyIcon, fonticon
 
+    color = 'white' if theme == 'dark' else 'black'
     if icn := getattr(icon, theme, ""):
         if icn.startswith("file://"):
             return QIcon(QUrl(icn).toLocalFile())
         elif ":" in icn:
-            return QIconifyIcon(icn)
+            return QIconifyIcon(icn, color=color)
         else:
-            return fonticon.icon(icn)
+            return fonticon.icon(icn, color=color)
     return QIcon()  # pragma: no cover


### PR DESCRIPTION
When icons are provided via fonticons or iconify, theme is currently disergarded. Defaulting to black/white should be at least a tiny bit nicer than just black!