### PR TITLE
WIP: KeyBinding: Flexible equality

### DIFF
--- a/src/app_model/types/_keys/_keybindings.py
+++ b/src/app_model/types/_keys/_keybindings.py
@@ -200,8 +200,11 @@ class KeyBinding:
         return f"<{self.__class__.__name__} at {hex(id(self))}: {self}>"
 
     def __eq__(self, other: Any) -> bool:
-        if isinstance(other, KeyBinding):
-            return self.parts == other.parts
+        try:
+            other_kb = self.validate(other)
+            return self.parts == other_kb.parts
+        except TypeError:
+            pass
         return NotImplemented
 
     def __len__(self) -> int:

--- a/tests/test_keybindings.py
+++ b/tests/test_keybindings.py
@@ -186,6 +186,7 @@ def test_eq() -> None:
     kb = KeyBinding.from_str("A")
     assert kb == "A"
     assert kb == kb.to_int()
+    assert kb == KeyCode.KeyA
     assert kb == SimpleKeyBinding.from_str("A")
 
 

--- a/tests/test_keybindings.py
+++ b/tests/test_keybindings.py
@@ -182,6 +182,13 @@ def test_in_model() -> None:
     assert m.model_dump_json() == '{"key":"Shift+A B"}'
 
 
+def test_eq() -> None:
+    kb = KeyBinding.from_str("A")
+    assert kb == "A"
+    assert kb == kb.to_int()
+    assert kb == SimpleKeyBinding.from_str("A")
+
+
 def test_standard_keybindings() -> None:
     class M(BaseModel):
         key: KeyBindingRule


### PR DESCRIPTION
Hi!

I was experimenting with this repo over in scenex for its key bindings model, and I was finding it tedious to check key binding equality. For example, if I want to know whether the left arrow was pressed, it'd be nice to say "kb == KeyCode.LeftArrow`, but that does not work as is. Was wondering whether a syntax like the following would be problematic?

Of course, if we like more "magical" equality checks, there are probably more things to do. Other equality checks, hashing checks, etc.