### PR TITLE
tests: Use dependency-group for napari testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,7 @@ jobs:
     secrets: inherit
 
   test_napari:
-    uses: pyapp-kit/workflows/.github/workflows/test-dependents.yml@v2
+    uses: pyapp-kit/workflows/.github/workflows/test-dependents.yml@65abcc0b091a0d45dbe3c589266160cc9b62f8dc
     with:
       dependency-repo: napari/napari
       dependency-group: "testing"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,7 @@ jobs:
     secrets: inherit
 
   test_napari:
-    uses: pyapp-kit/workflows/.github/workflows/test-dependents.yml@65abcc0b091a0d45dbe3c589266160cc9b62f8dc
+    uses: pyapp-kit/workflows/.github/workflows/test-dependents.yml@main
     with:
       dependency-repo: napari/napari
       dependency-group: "testing"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,7 @@ jobs:
     uses: pyapp-kit/workflows/.github/workflows/test-dependents.yml@v2
     with:
       dependency-repo: napari/napari
-      dependency-extras: "testing"
+      dependency-group: "testing"
       qt: ${{ matrix.qt }}
       pytest-args: 'src/napari/_qt/_qapp_model src/napari/_app_model src/napari/utils/_tests/test_key_bindings.py --import-mode=importlib -k "not async and not qt_dims_2"'
       python-version: "3.12"


### PR DESCRIPTION
napari/napari#8704 is aiming to drop `optional-dependencies` this uses the `dependency-group` definition from https://github.com/pyapp-kit/workflows/blob/main/.github/workflows/test-dependents.yml

🍻 
